### PR TITLE
bubble-mode 1.5.0: hide per-reply timer chips in Bot Chat quiet mode

### DIFF
--- a/bubble-mode/CHANGELOG.md
+++ b/bubble-mode/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.5.0 — 2026-08-28
+
+- Quiet chat also hides the per-reply timer chips ("3s", "7s") in Bot Chat.
+  "Bubble Mode: toggle work rows" brings them back along with the rest.
+
 ## 1.4.2 — 2026-08-28
 
 - Stray pre-reply mini-bubble fully fixed (containers whose children are all

--- a/bubble-mode/plugin.js
+++ b/bubble-mode/plugin.js
@@ -113,7 +113,8 @@ body.hermes-bubble-mode [data-chat-surface] [data-slot="aui_assistant-message-co
    with "Bubble Mode: toggle work rows". */
 body.hermes-bubble-quiet [data-chat-surface] [data-slot="aui_thinking-disclosure"],
 body.hermes-bubble-quiet [data-chat-surface] [data-slot="aui_reasoning-text"],
-body.hermes-bubble-quiet [data-chat-surface] [data-slot="aui_turn-activity"] {
+body.hermes-bubble-quiet [data-chat-surface] [data-slot="aui_turn-activity"],
+body.hermes-bubble-quiet [data-chat-surface] [data-slot="aui_turn-duration"] {
   display: none;
 }
 


### PR DESCRIPTION
Hides the "3s"/"7s" turn-duration chips under replies in the canonical Bot Chat (quiet mode), matching the texting look. "Bubble Mode: toggle work rows" restores them together with thinking/tool rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)