### PR TITLE
docs: full refresh to match tonight's releases

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,7 +66,13 @@ curl -fsSL https://raw.githubusercontent.com/thomasbek3/hermes-bot-kit/master/te
 ```
 
 Verify: `hermes plugins list` shows `texting-style enabled`. Takes effect on
-new sessions only (`/new` or gateway restart). Uninstall: remove
+the next message in each Bot Chat (a pre_llm_call backfill hook covers
+existing eternal sessions whose frozen prompt predates the plugin) — but the
+NEW PLUGIN CODE only loads when the agent process restarts: after
+install/update, restart Hermes Desktop or kill the per-profile serve
+daemons (`pkill -f "hermes --profile <name> serve"`; they respawn on
+demand). Debug: `TS_DEBUG=1` logs hook decisions to
+`/tmp/texting-style-debug.log`. Uninstall: remove
 `<profile-home>/plugins/texting-style` and its `plugins.enabled` entry.
 
 ## Optional: give bots hands (agent plugin, Orgo computers)
@@ -96,6 +102,21 @@ storage under `hermes.plugin.bubble-mode.*` / `hermes.plugin.computer-viewer.*`.
 
 - Requires Hermes Desktop ≥ 0.20.5. On older builds the Computer pane is
   zero-size; there is no workaround, update the app.
+- Desktop Bot Chats are served by long-lived per-profile
+  `hermes --profile <name> serve` daemons that SURVIVE app restarts. If a
+  plugin change "doesn't take", kill those daemons (they respawn on demand)
+  — do not keep redeploying files.
+- "Bot Chat" is the desktop's canonical per-bot conversation (session
+  literally titled `Bot Chat`, user-locked). Both bubble-mode's visuals and
+  texting-style's doctrine gate on it; every other session renders stock by
+  design.
+- A serve restart under an open Bot Chat tab can scramble the tab's caption
+  (stock Hermes bug; data unaffected). bubble-mode 1.4.0+ styling survives
+  it; the caption itself is restored by: close tab → quit app → relaunch →
+  click the bot.
+- CLI probes cannot reach a canonical Bot Chat: `-z --continue "Bot Chat"`
+  and `--resume <id>` both fork new sessions. Only the desktop UI talks to
+  the real one.
 - Both plugins fail safe: if a Hermes update renames internal hooks, chats
   render stock / the pane stays empty — nothing crashes.
 - The repo was formerly `hermes-computer-viewer`; old raw URLs still work

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,22 @@
 Per-plugin history lives in [bubble-mode/CHANGELOG.md](bubble-mode/CHANGELOG.md)
 and [computer-viewer/CHANGELOG.md](computer-viewer/CHANGELOG.md).
 
+## 2026-08-28 (later) — bubble-mode 1.5.0 · computer-viewer fixes
+
+- bubble-mode 1.2.0–1.5.0: SMS look gated to the canonical Bot Chat tab
+  only; sticky tab memory survives the stock caption-scramble bug;
+  iMessage-style "..." typing indicator (Grok-Bot-sized); per-reply timer
+  chips hidden in quiet mode; stray empty pre-reply bubble fixed.
+- computer-viewer: auto-connects when the bot starts using its computer
+  (live-turn orgo tool rows; never on history renders); docks on top of the
+  Cronjobs tile so stock's every-launch dock enforcement converges to one
+  stable right column; overlay DOM moves guarded — the
+  "Something broke in the interface" removeChild shell crash is fixed.
+- texting-style 1.1.x: pre_llm_call backfill delivers the doctrine to
+  existing eternal Bot Chats; session lookup searches all profile state.dbs;
+  TS_DEBUG decision log; doctrine self-identifies as plugin-delivered.
+- Docs refreshed across the repo to match all of the above.
+
 ## 2026-08-28 — bubble-mode 1.1.0 · texting-style 1.1.0
 
 - bubble-mode: mixed text+code fix (1.0.1) and quiet chat — Bot Mode hides

--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ Two independent plugins, one install:
 
 | Plugin | What it does |
 |---|---|
-| 💬 **[Bubble Mode](bubble-mode/)** | iMessage-style chat bubbles — **only in Bot Mode**. Your messages right in light gray, the bot's left in dark gray. Cards, code blocks, tool runs, and approvals keep their stock chrome; Sessions view is never touched. Pure CSS, fails safe. |
-| 🖥️ **[Computer](computer-viewer/)** | A live remote-desktop pane docked in Hermes — cloud boxes (Orgo, VPS, Docker), spare Macs, Windows PCs, Linux machines, switchable like a KVM for your fleet. Optional H.264 HD mode, per-bot computer bindings, and an agent plugin that gives your bots **hands** (shell + screenshot/click/type) on their pinned machine. |
+| 💬 **[Bubble Mode](bubble-mode/)** | The full texting look — **only on each bot's main Bot Chat**: iMessage bubbles, a "..." typing indicator while the bot works, and thinking/tool/timer noise hidden (approvals always visible; one palette command brings the work rows back). Work sessions, side tabs, and Sessions view are never touched. Pure CSS, fails safe. |
+| 🖥️ **[Computer](computer-viewer/)** | A live remote-desktop pane docked in Hermes — cloud boxes (Orgo, VPS, Docker), spare Macs, Windows PCs, Linux machines, switchable like a KVM for your fleet. **Auto-connects the moment your bot starts using its computer**, so you watch it work. Optional H.264 HD mode, per-bot computer bindings, and an agent plugin that gives your bots **hands** (shell + screenshot/click/type) on their pinned machine. |
 | 📱 **[texting-style](texting-style/)** | An **agent plugin** that makes bots *talk* like texting, not just look like it — and **only in Bot Mode chats**: short replies, mirrors your length, no walls of text, "on it" then the result. Regular Sessions stay stock. Per-profile install, one editable doctrine string. |
 
 <p align="center">
@@ -50,7 +50,9 @@ Two independent plugins, one install:
 │  │ All green. Backups ran,  │              │  ← your bot
 │  │ nothing needs you.       │              │
 │  ╰──────────────────────────╯              │
-│  [ tool run: check_backups ✓ ]             │  ← tool rows stay stock
+│  ╭─────╮                                   │
+│  │ ⋯  │                                    │  ← typing while it works
+│  ╰─────╯                                   │
 └────────────────────────────────────────────┘
 ```
 

--- a/bubble-mode/README.md
+++ b/bubble-mode/README.md
@@ -1,26 +1,37 @@
 # Bubble Mode for Hermes Desktop
 
-> Part of [**Hermes Bot Kit**](../README.md) — install both plugins with one
-> command from the kit root. Everything below also works standalone.
+> Part of [**Hermes Bot Kit**](../README.md) — install both desktop plugins
+> with one command from the kit root. Everything below also works standalone.
 
-iMessage-style chat bubbles — **only in Bot Mode**. Your Sessions view stays
+The full iMessage texting look — **only on each bot's canonical Bot Chat**
+(the main conversation you get by tapping a bot in Bot Mode). Everything else
+— Sessions view, long-form side tabs, group rooms, new drafts — stays
 exactly as it is.
 
-Your messages render as light-gray bubbles on the right, the agent's as
-darker-gray bubbles on the left (Grok-Bot-style palette). Cards, code blocks,
-tool runs, approvals, and thinking sections keep their normal chrome — only
-plain conversation text becomes bubbles.
+On the Bot Chat tab you get:
+
+- **Bubbles.** Your messages light gray on the right, the bot's dark gray on
+  the left (Grok-Bot palette). Cards, code blocks, and images keep stock
+  chrome; mixed text+code replies split into text bubbles around the cards.
+- **Quiet chat.** Thinking disclosures, reasoning text, activity rows, tool
+  blocks, and per-reply timer chips ("3s") are hidden. Approvals always stay
+  visible. Bring the work rows back any time with
+  **⌘⇧P → Bubble Mode: toggle work rows** (persists).
+- **Typing indicator.** While the bot thinks or works, an iMessage-style
+  "..." pill with pulsing dots shows where the reply will land.
 
 ```
 ┌────────────────────────────────────────────┐
 │                      ╭─────────────────╮   │
 │                      │ hey, status?    │   │  ← you (light gray)
 │                      ╰─────────────────╯   │
+│  ╭─────╮                                   │
+│  │ ⋯  │                                    │  ← bot is typing/working
+│  ╰─────╯                                   │
 │  ╭──────────────────────────╮              │
 │  │ All green. Backups ran,  │              │  ← your bot (dark gray)
 │  │ nothing needs you.       │              │
 │  ╰──────────────────────────╯              │
-│  [ tool run: check_backups ✓ ]             │  ← tool rows stay stock
 └────────────────────────────────────────────┘
 ```
 
@@ -31,9 +42,9 @@ curl -fsSL https://raw.githubusercontent.com/thomasbek3/hermes-bot-kit/master/bu
 ```
 
 Then in Hermes Desktop: **⌘⇧P → Reload plugins** (or restart the app). Done —
-every Bot Mode chat gets bubbles, including bots you add later. The script is
-idempotent, needs no sudo, prompts for nothing, verifies what it downloaded,
-and backs up any existing copy before overwriting.
+every bot's Bot Chat gets the look, including bots you add later. The script
+is idempotent, needs no sudo, prompts for nothing, verifies what it
+downloaded, and backs up any existing copy before overwriting.
 
 Manual install (equivalent):
 
@@ -44,20 +55,35 @@ cp plugin.js ~/.hermes/desktop-plugins/bubble-mode/plugin.js
 
 The folder must be named `bubble-mode` (it must match the plugin id).
 
-Toggle any time: **⌘⇧P → Bubble Mode: toggle** (persists across restarts).
+Palette commands (both persist across restarts):
+
+| Command | Effect |
+|---|---|
+| **Bubble Mode: toggle** | Whole plugin on/off. |
+| **Bubble Mode: toggle work rows** | Show/hide thinking, tool, and timer rows inside Bot Chat. |
 
 ## Highlights
 
-- **Bot Mode only.** Detection reconstructs "a Bot Mode chat owns the
-  screen" from public SDK signals and DOM stamps — Sessions chats, group
-  rooms, and the Bots home screen are never styled.
-- **Everything works, only looks change.** Pure CSS plus one body-class
-  toggle. No core patches, no React wrapping, no network calls, read-only
-  SDK use. Streaming, editing, reactions, cards — all untouched.
-- **Fleet-proof.** It skins the Bot Mode surface, not individual agents, so
+- **Bot Chat only.** Detection reconstructs "the canonical Bot Chat owns the
+  screen" from public SDK signals, DOM stamps, and the selected tab's
+  "Bot Chat" title — the same gate Hermes core uses agent-side. Sessions
+  chats, Bot Mode side tabs, group rooms, and the Bots home screen are never
+  styled.
+- **Survives caption scrambles.** A serve-process restart under an open Bot
+  Chat can make the desktop re-bind the tab and lose its "Bot Chat" caption
+  (stock Hermes bug). Any tab once seen labeled "Bot Chat" is remembered per
+  install, so the styling holds even when the caption is wrong.
+- **Everything works, only looks change.** Pure CSS plus body-class toggles.
+  No core patches, no React wrapping, no network calls, read-only SDK use.
+  Streaming, editing, reactions, cards, approvals — all untouched.
+- **Fleet-proof.** It skins the Bot Chat surface, not individual agents, so
   every current and future bot gets the look with zero per-agent setup.
 - **Fails safe.** If a Hermes update renames the hooks it latches onto,
   bubbles silently stop applying and chats render stock. Nothing breaks.
+
+Pairs with the kit's [texting-style](../texting-style/) agent plugin, which
+makes the bot *write* like a texter in the same chats this plugin makes
+*look* like texting.
 
 > **Known issues & design notes:** [docs/KNOWN-ISSUES.md](docs/KNOWN-ISSUES.md).
 > Full DOM/SDK research behind the detection logic: [docs/BUILD-NOTES.md](docs/BUILD-NOTES.md).
@@ -74,12 +100,14 @@ Toggle any time: **⌘⇧P → Bubble Mode: toggle** (persists across restarts).
   ([#71961](https://github.com/NousResearch/hermes-agent/pull/71961),
   [#41402](https://github.com/NousResearch/hermes-agent/pull/41402)), both
   stalled. They're all-or-nothing: bubbles everywhere or nowhere. This plugin
-  exists because Bot Mode should feel like texting while work sessions keep
-  the full-width transcript. If one of those PRs merges, the two coexist.
+  exists because the bot's main thread should feel like texting while work
+  sessions keep the full-width transcript. If one of those PRs merges, the
+  two coexist.
 - The hooks this plugin reads (`data-slot` message attributes, the
-  `hermes-bots:pane` id, chat-surface stamps) are stable in v0.20.x but not a
-  public API. [docs/KNOWN-ISSUES.md](docs/KNOWN-ISSUES.md) documents the
-  failure mode (silent no-op) and the re-tune path;
+  `hermes-bots:pane` id, chat-surface stamps, session-tile tab labels) are
+  stable in v0.20.x but not a public API.
+  [docs/KNOWN-ISSUES.md](docs/KNOWN-ISSUES.md) documents the failure mode
+  (silent no-op) and the re-tune path;
   [docs/BUILD-NOTES.md](docs/BUILD-NOTES.md) maps every hook to its location
   in the Hermes source so future maintenance is a find-and-replace, not a
   rediscovery.
@@ -93,6 +121,7 @@ Tuned for the dark theme, sampled from Grok Bot:
 | Your bubble (right) | `#4a4a4e`, ink `#f2f2f3` |
 | Agent bubble (left) | `#2b2b2e`, ink `#e8e8ea` |
 | Radius | `18px`, `4px` tail on the inner corner |
+| Typing pill | `#2b2b2e`, 6px dots, 16px radius |
 
 Want different colors? They live in one obvious `CSS` block at the top of
 `plugin.js` — edit the hex values and reload plugins.
@@ -111,15 +140,18 @@ CHANGELOG.md         version history
 
 Plugin id: `bubble-mode` (folder name must match).
 
-## How it detects Bot Mode
+## How it detects the Bot Chat
 
 A disk plugin can't import the bundled hermes-bots plugin's internal state,
-so Bubble Mode reconstructs the same question from public signals:
+so Bubble Mode reconstructs the question from public signals:
 `host.paneVisibility('hermes-bots:pane')`, the Bots home / group-chat tab
-state, and the chat-surface DOM stamps (`data-composer-target`,
-`data-session-anchor`), skipping hidden keep-alive panes. The full derivation
-— including the signals that looked tempting and were rejected — is in
-[docs/BUILD-NOTES.md](docs/BUILD-NOTES.md).
+state, and — since 1.2.0 — the selected session tab's label: only the tab
+titled **"Bot Chat"** (the desktop's canonical per-bot conversation, the same
+title Hermes core gates on in `tools/bot_mode_probe.py`) gets the look.
+Since 1.4.0 the plugin also remembers tab ids it has seen correctly labeled,
+so a desktop tab-caption scramble can't turn the styling off. The full
+derivation — including the signals that looked tempting and were rejected —
+is in [docs/BUILD-NOTES.md](docs/BUILD-NOTES.md).
 
 ## License
 

--- a/bubble-mode/docs/KNOWN-ISSUES.md
+++ b/bubble-mode/docs/KNOWN-ISSUES.md
@@ -1,18 +1,26 @@
 # Known issues & design notes
 
 Everything non-obvious we hit while building and testing on real machines.
-None of these break chats — the plugin's failure mode is always "bubbles
-simply don't apply".
+None of these break chats — the plugin's failure mode is always "the SMS look
+simply doesn't apply".
 
 ## By design
 
-- **Group chats stay unstyled.** Bot Mode group rooms use a custom log view
-  with none of the normal message markup, so bubbles are deliberately off
-  there. Nothing to fix.
-- **Cards, code blocks, tool runs, approvals, and thinking sections keep
-  their stock chrome.** Only plain conversation text becomes a bubble. When a
-  reply mixes text and a card, the text paragraphs get bubbles and the card
-  renders untouched.
+- **Only the canonical Bot Chat is styled (since 1.2.0).** The gate is the
+  selected tab titled "Bot Chat" — the desktop's per-bot main conversation,
+  the same title Hermes core gates on in `tools/bot_mode_probe.py`. Long-form
+  side tabs, new drafts, Sessions view, and group chats all render stock,
+  even inside Bot Mode.
+- **Work rows are hidden by default (since 1.1.0).** Thinking disclosures,
+  reasoning text, activity rows, tool blocks, and per-reply timer chips are
+  `display: none` in Bot Chat. Approvals are never hidden, and the typing
+  indicator shows the bot is busy. "Bubble Mode: toggle work rows" restores
+  everything (persisted).
+- **Cards, code blocks, and images keep their stock chrome.** Only plain
+  conversation text becomes a bubble. When a reply mixes text and cards, the
+  text paragraphs get bubbles (with small gaps) and the cards render
+  untouched. The split triggers on any `pre`, `table`, mermaid block, or
+  image — not just known card slots (1.0.1).
 - **The edit composer is tinted too.** Editing one of your sent messages
   reuses the same bubble surface, so the editor shows your bubble color.
   Cosmetic, accepted.
@@ -21,17 +29,34 @@ simply don't apply".
 
 - **Colors are tuned for the dark theme.** User bubble `#4a4a4e`, assistant
   `#2b2b2e` (Grok-Bot palette). On a light theme they'll look heavy — edit
-  the two hex values in the `CSS` block at the top of `plugin.js`.
+  the hex values in the `CSS` block at the top of `plugin.js`.
 - **A brand-new bot draft may bubble a beat late.** Detection reads the
   pane/tab state; a tab whose chat surface hasn't painted yet is caught on
   the next frame by the DOM observer. You may see one unstyled frame.
 
+## Upstream bug: tab caption scramble (worked around in 1.4.0)
+
+Stock Hermes Desktop: when the per-profile `hermes … serve` process backing
+an open Bot Chat restarts (crash, kill, heavy load), the desktop re-binds
+the tab as a plain session tab and the "Bot Chat" caption is replaced by a
+message-derived label. The session itself is untouched — its DB title stays
+`Bot Chat` (user provenance) — only the visible caption is wrong.
+
+- **Plugin impact (fixed):** the label gate would turn the styling off.
+  Since 1.4.0 the plugin remembers tab ids it has seen correctly labeled
+  (persisted, capped at 64), so styling survives the scramble.
+- **Cosmetic remainder (upstream):** the caption itself stays wrong until
+  you close the tab, quit the app (so the layout saves clean), relaunch, and
+  click the bot — the canonical open path hard-codes the caption. A proper
+  fix belongs upstream: the re-bind path should re-check the session's root
+  title the way `createCanonicalChat` does.
+
 ## Update risk (the honest part)
 
 The plugin latches onto Hermes Desktop's rendering hooks (`data-slot`
-message attributes, the `hermes-bots:pane` id, chat-surface stamps). These
-are stable in v0.20.x but not a public API. If a future Hermes update renames
-them:
+message attributes, `data-streamdown` markers, the `hermes-bots:pane` id,
+chat-surface stamps, session-tile tab labels). These are stable in v0.20.x
+but not a public API. If a future Hermes update renames them:
 
 - **Failure mode:** bubbles silently stop applying; chats render stock.
   Nothing crashes, no messages are lost.
@@ -46,4 +71,4 @@ Hermes has open PRs for an **app-wide** bubble layout
 [hermes-agent#41402](https://github.com/NousResearch/hermes-agent/pull/41402))
 — both stalled without a maintainer decision as of 2026-08. If one merges,
 that becomes an all-or-nothing setting; this plugin remains the
-Bot-Mode-only option and the two can coexist (worst case you'd turn one off).
+Bot-Chat-only option and the two can coexist (worst case you'd turn one off).

--- a/computer-viewer/README.md
+++ b/computer-viewer/README.md
@@ -54,6 +54,11 @@ viewed through the pane's noVNC connection.</em></p>
   path. One **HD** toggle; VNC is the silent safety net.
 - **Multi-bot aware.** Per-bot computer bindings — each of your profiles can
   have its own machine, and the pane follows the focused chat.
+- **Auto-connects when your bot goes to work.** The moment a fresh
+  orgo-computer tool call appears in a live turn, the pane wakes itself
+  (clearing a manual Disconnect hold) so you watch the bot drive — the
+  Grok Bot behavior. Never triggered by scrolling old history; at most one
+  wake per 30s.
 - **Bots with hands, not just eyes.** The optional `orgo-computer` agent
   plugin lets your bots run shell commands and delegate GUI tasks on their
   pinned computer. Watch the pane while the bot works inside it.
@@ -70,10 +75,12 @@ viewed through the pane's noVNC connection.</em></p>
 - **Requires Hermes Desktop ≥ 0.20.5 (2026.8.19).** The 2026-08 stock releases
   reworked the pane shell: `placement: 'right'` now means the collapsible ⌘J
   sidebar (hidden by default), and `host.paneVisibility` became read-only.
-  This plugin docks with `placement: 'main'` + an enforced workspace dock, the
-  same pattern the bundled Bot Mode Cronjobs tile uses, so it stays visible on
-  fresh installs. Older plugin versions show a zero-size pane on current stock
-  — update to this version.
+  This plugin docks with `placement: 'main'` + an enforced dock ON TOP of the
+  bundled Cronjobs tile, so it stays visible on fresh installs. (Stock's
+  Cronjobs pane re-enforces its own dock on every app launch, stomping manual
+  arrangements; targeting it makes both enforcements converge to one stable
+  right column — Computer above Cronjobs.) Older plugin versions show a
+  zero-size pane on current stock — update to this version.
 
 ## Repository layout
 
@@ -730,7 +737,9 @@ never cropped.
 session and the HD stream together, and it cancels reconnect backoff. The
 pane stays **Disconnected** with a **Connect** button. Collapsing and
 reopening the pane does not auto-connect that computer until you click
-**Connect**. A full Hermes app restart returns to the usual auto-connect
+**Connect** — with one exception: if the bot starts using its computer
+during a live turn, the pane wakes itself (that's exactly when you want
+eyes on it). A full Hermes app restart returns to the usual auto-connect
 behavior. The hold is in-memory only; nothing extra is written to plugin
 storage.
 

--- a/computer-viewer/docs/KNOWN-ISSUES.md
+++ b/computer-viewer/docs/KNOWN-ISSUES.md
@@ -242,9 +242,12 @@ default and spends AI credits — do not enable it just to click.
   `dock: { pane: 'workspace', pos: 'right', enforce: true }`; toggle by
   registering/disposing the pane contribution; mount the fullscreen overlay
   from the status-bar item instead of inside the (hideable) pane.
-- **Known rough edge:** the fullscreen overlay re-appends its node to
-  `document.body` after paints (the SDK exports no portal; `react-dom` is
-  blocked by the loader allowlist). Rarely, a click can race React
-  reconciliation into a `removeChild` crash caught by the app's error screen —
-  **Reload window** recovers, nothing is lost. Will be replaced with a
+- **Fixed (2026-08-28): the removeChild shell crash.** The fullscreen
+  overlay re-appends its node to `document.body` after paints (the SDK
+  exports no portal; `react-dom` is blocked by the loader allowlist), and a
+  click could race React reconciliation into a `removeChild` crash caught by
+  the app's error screen ("Something broke in the interface"). The overlay's
+  React-owned container is now guarded: mismatched removals no-op and
+  mismatched insert anchors fall back to append — scoped to that single
+  element, no global prototype patch. Will still be replaced with a real
   portal the moment the plugin SDK exports one.

--- a/texting-style/README.md
+++ b/texting-style/README.md
@@ -3,14 +3,15 @@
 > Part of [**Hermes Bot Kit**](../README.md). Bubble Mode makes chats *look*
 > like texting; this makes your bots *talk* like texting.
 
-A tiny Hermes **agent plugin** (not a desktop plugin) that adds one bounded
-system-prompt section to new **Bot Mode chats only** (by default): reply
-short (1-2 sentences), mirror the user's length, no headers or bullet lists in chat, ack
-first then report when doing real work, and go long only when asked or when
-the deliverable itself is long.
+A tiny Hermes **agent plugin** (not a desktop plugin) that applies an SMS
+doctrine to each bot's canonical **Bot Chat only**: reply short by default
+(1-2 sentences), mirror the user's length, no headers or bullet lists in
+chat, ack first then report when doing real work, and go long only when
+asked or when the deliverable itself is long. Work sessions and every other
+conversation stay long-form.
 
-No tools, no hooks, no network calls. The full doctrine is the `DOCTRINE`
-string at the top of [`__init__.py`](__init__.py) — edit it to taste.
+No tools, no network calls. The full doctrine is the `DOCTRINE` string at
+the top of [`__init__.py`](__init__.py) — edit it to taste.
 
 ## Install
 
@@ -24,8 +25,11 @@ plus `~/.hermes/profiles/*`). Pick profiles with
 the plugin is symlinked so `git pull` updates it; curl-piped installs copy
 the files.
 
-Takes effect on **new sessions** (prompt sections are frozen per session):
-`/new` in a chat, or restart the gateway.
+**Takes effect on the next message** in each Bot Chat — including chats that
+already exist (see How it works). One caveat: the agent *processes* serving
+open desktop chats are long-lived, so after installing or updating the
+plugin code, restart Hermes Desktop (or `pkill -f "hermes --profile <name> serve"`
+— they respawn on demand) so the new code actually loads.
 
 ## Config
 
@@ -33,17 +37,35 @@ Per profile, in the plugin's config (`config_schema` keys):
 
 | Key | Default | Meaning |
 |---|---|---|
-| `enabled` | `true` | Master switch (next session). |
+| `enabled` | `true` | Master switch. |
 | `bot_chat_only` | `true` | Apply only to Bot Mode chats — sessions titled `Bot Chat`, the desktop's canonical per-bot conversation (the exact gate Hermes core uses in `tools/bot_mode_probe.py`). Regular Sessions stay stock even in the same profile. `false` = everywhere. |
 | `platforms` | `""` (all) | Comma-separated allowlist, e.g. `desktop` or `desktop,telegram` — other platforms get stock behavior. |
 | `extra_rules` | `""` | One extra rule line appended to the doctrine. |
 
 ## How it works
 
-`register_system_prompt_section("texting-style.sms-register", …)` — Hermes's
-cache-safe way for a plugin to add durable guidance to the system prompt
-(bounded at 4,000 chars, rendered once per new session, named + logged at
-session start). Nothing is injected per turn and the prompt cache stays warm.
+Two delivery paths, so it works on brand-new and years-old chats alike:
+
+1. **System-prompt section** — `register_system_prompt_section(
+   "texting-style.sms-register", …)`: Hermes's cache-safe way for a plugin
+   to add durable guidance to the system prompt (bounded at 4,000 chars,
+   rendered once per new session, named + logged at session start).
+2. **Backfill hook** — canonical Bot Chats are *eternal sessions*: their
+   frozen prompt only rebuilds on a capability-epoch change, so a chat that
+   predates this plugin would never render the section. A `pre_llm_call`
+   hook covers the gap: each turn, if the session is a Bot Chat whose stored
+   system prompt lacks the doctrine, the doctrine is injected as per-turn
+   context. Once an epoch rebuild bakes the section in, the hook goes
+   silent automatically. The bot will truthfully say the rules are "not in
+   my frozen prompt" — they arrive with each message instead, and the
+   doctrine says so.
+
+Session titles are read from the profile's `state.db` (read-only, searching
+every profile's DB — some Hermes builds mis-resolve the active profile home).
+Any lookup failure fails safe to stock behavior.
+
+Debugging: run the agent with `TS_DEBUG=1` and the hook logs each decision
+(`INJECTING` / `blocked: …`) to `/tmp/texting-style-debug.log`.
 
 Uninstall: remove `plugins/texting-style` from the profile home and drop
 `texting-style` from `plugins.enabled` in its `config.yaml`.

--- a/texting-style/install.sh
+++ b/texting-style/install.sh
@@ -223,6 +223,8 @@ while IFS="$(printf '\t')" read -r name home; do
 done < "${SELECTED}"
 
 echo
-echo "Done. Applies to NEW sessions (prompt sections are frozen per session):"
-echo "  /new in a chat, or restart the gateway."
+echo "Done. Applies to each bot's canonical Bot Chat on its next message"
+echo "(a backfill hook covers existing chats). New plugin CODE loads when the"
+echo "agent process restarts: restart Hermes Desktop, or kill the per-profile"
+echo "serve daemons (pkill -f 'hermes --profile <name> serve'; they respawn)."
 echo "Scope to certain platforms via plugin config 'platforms' (e.g. 'desktop')."


### PR DESCRIPTION
Every README, AGENTS.md, KNOWN-ISSUES, changelog, and installer message updated to reflect: Bot-Chat-only gating, quiet chat + typing indicator, sticky tab memory, the upstream caption-scramble and dock-enforce bugs (and our workarounds), texting-style's backfill hook, computer-viewer auto-connect, and the removeChild crash guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)