### PR TITLE
install-agent-plugin: keep the Orgo API key out of argv

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,11 +93,12 @@ Orgo computer:
 
 ```bash
 git clone https://github.com/thomasbek3/hermes-bot-kit.git
-bash hermes-bot-kit/computer-viewer/install-agent-plugin.sh --profiles <name1>,<name2> --yes --api-key <ORGO_API_KEY>
+bash hermes-bot-kit/computer-viewer/install-agent-plugin.sh --profiles <name1>,<name2> --yes --api-key-stdin <<< "$ORGO_API_KEY"
 ```
 
-Requires an Orgo API key from the user. Never invent or reuse keys found in
-files without the user's say-so.
+Requires an Orgo API key from the user. The key never appears in argv or
+shell history this way. Never invent or reuse keys found in files without
+the user's say-so.
 
 ## Uninstall
 

--- a/computer-viewer/README.md
+++ b/computer-viewer/README.md
@@ -190,8 +190,12 @@ Install into one or every Hermes profile:
 
 ```bash
 bash install-agent-plugin.sh            # all profiles, prompts once for the key
-bash install-agent-plugin.sh --profiles default,parker --yes --api-key sk_live_xxx
+bash install-agent-plugin.sh --profiles default,parker --yes --api-key-stdin <<< "$ORGO_API_KEY"
+bash install-agent-plugin.sh --profiles default,parker --yes --api-key-file ~/.config/orgo/api-key
 ```
+
+The key never appears in argv or shell history this way. `--api-key KEY` still
+works but is discouraged (visible in the process list and shell history).
 
 Then pin a computer per profile with `/computer` in that chat. The plugin is
 per-profile on purpose: parker's bot can drive one Orgo box while alfred's

--- a/computer-viewer/install-agent-plugin.sh
+++ b/computer-viewer/install-agent-plugin.sh
@@ -15,9 +15,14 @@ Options:
   --all                 Install into every discovered profile (default)
   --profiles LIST       Comma-separated profile names (default, ava, ...)
   --yes                 Do not prompt for profile selection
-  --api-key KEY         Write this ORGO_API_KEY into selected profiles that
+  --api-key-stdin       Read ORGO_API_KEY from stdin (one line). Never printed.
+  --api-key-file PATH   Read ORGO_API_KEY from the first line of PATH.
+  --api-key KEY         (discouraged: visible in ps and shell history)
+                        Write this ORGO_API_KEY into selected profiles that
                         lack a key. Never printed. If omitted, you are
                         prompted once (empty + --yes writes ORGO_API_KEY=).
+                        Prefer --api-key-stdin, --api-key-file, or the
+                        ORGO_API_KEY environment variable.
   -h, --help            Show this help
 
 Re-runs are idempotent: existing symlinks, enabled entries, and non-empty
@@ -34,6 +39,12 @@ ALL_FLAG=0
 YES=0
 PROFILES_ARG=""
 API_KEY_ARG=""
+API_KEY_SET=0
+API_KEY_STDIN=0
+API_KEY_FILE=""
+API_KEY_FILE_SET=0
+
+ARGV_KEY_WARNING="WARNING: --api-key puts the key in the process list and shell history. Prefer --api-key-stdin, --api-key-file, or the ORGO_API_KEY environment variable."
 
 while [ $# -gt 0 ]; do
   case "$1" in
@@ -60,16 +71,42 @@ while [ $# -gt 0 ]; do
       YES=1
       shift
       ;;
-    --api-key)
-      API_KEY_ARG="${2:-}"
-      if [ -z "${API_KEY_ARG}" ]; then
-        echo "install-agent-plugin.sh: --api-key requires a value" >&2
+    --api-key-stdin)
+      API_KEY_STDIN=1
+      shift
+      ;;
+    --api-key-file)
+      API_KEY_FILE="${2:-}"
+      API_KEY_FILE_SET=1
+      if [ -z "${API_KEY_FILE}" ]; then
+        echo "install-agent-plugin.sh: --api-key-file requires a path" >&2
         exit 2
       fi
       shift 2
       ;;
+    --api-key-file=*)
+      API_KEY_FILE="${1#--api-key-file=}"
+      API_KEY_FILE_SET=1
+      if [ -z "${API_KEY_FILE}" ]; then
+        echo "install-agent-plugin.sh: --api-key-file requires a path" >&2
+        exit 2
+      fi
+      shift
+      ;;
+    --api-key)
+      API_KEY_ARG="${2:-}"
+      API_KEY_SET=1
+      if [ -z "${API_KEY_ARG}" ]; then
+        echo "install-agent-plugin.sh: --api-key requires a value" >&2
+        exit 2
+      fi
+      echo "${ARGV_KEY_WARNING}" >&2
+      shift 2
+      ;;
     --api-key=*)
       API_KEY_ARG="${1#--api-key=}"
+      API_KEY_SET=1
+      echo "${ARGV_KEY_WARNING}" >&2
       shift
       ;;
     -h|--help)
@@ -83,6 +120,47 @@ while [ $# -gt 0 ]; do
       ;;
   esac
 done
+
+explicit_key_flags=$((API_KEY_STDIN + API_KEY_FILE_SET + API_KEY_SET))
+if [ "${explicit_key_flags}" -gt 1 ]; then
+  echo "install-agent-plugin.sh: pass only one of --api-key-stdin, --api-key-file, --api-key" >&2
+  exit 2
+fi
+
+# Consume stdin now when asked, before profile selection or the
+# non-tty empty-key fallback can swallow it.
+API_KEY_STDIN_VALUE=""
+if [ "${API_KEY_STDIN}" -eq 1 ]; then
+  IFS= read -r API_KEY_STDIN_VALUE || true
+  API_KEY_STDIN_VALUE=${API_KEY_STDIN_VALUE%$'\r'}
+fi
+
+API_KEY_FILE_VALUE=""
+if [ "${API_KEY_FILE_SET}" -eq 1 ]; then
+  if [ ! -f "${API_KEY_FILE}" ]; then
+    echo "install-agent-plugin.sh: --api-key-file not found: ${API_KEY_FILE}" >&2
+    exit 2
+  fi
+  mode=""
+  if mode=$(stat -f '%Lp' "${API_KEY_FILE}" 2>/dev/null); then
+    :
+  elif mode=$(stat -c '%a' "${API_KEY_FILE}" 2>/dev/null); then
+    :
+  else
+    mode=""
+  fi
+  case "${mode}" in
+    *[!0-7]*|"")
+      ;;
+    *)
+      if [ $((8#${mode} & 8#044)) -ne 0 ]; then
+        echo "WARNING: --api-key-file ${API_KEY_FILE} is group- or world-readable" >&2
+      fi
+      ;;
+  esac
+  IFS= read -r API_KEY_FILE_VALUE < "${API_KEY_FILE}" || true
+  API_KEY_FILE_VALUE=${API_KEY_FILE_VALUE%$'\r'}
+fi
 
 if [ ! -f "${PLUGIN_SRC}/plugin.yaml" ] || [ ! -f "${PLUGIN_SRC}/__init__.py" ]; then
   echo "install-agent-plugin.sh: plugin source not found at ${PLUGIN_SRC}" >&2
@@ -342,7 +420,11 @@ done < "${SELECTED_FILE}"
 
 KEY_TO_WRITE=""
 if [ "${needs_key}" -eq 1 ]; then
-  if [ -n "${API_KEY_ARG}" ]; then
+  if [ "${API_KEY_STDIN}" -eq 1 ]; then
+    KEY_TO_WRITE=${API_KEY_STDIN_VALUE}
+  elif [ "${API_KEY_FILE_SET}" -eq 1 ]; then
+    KEY_TO_WRITE=${API_KEY_FILE_VALUE}
+  elif [ "${API_KEY_SET}" -eq 1 ]; then
     KEY_TO_WRITE=${API_KEY_ARG}
   elif [ -n "${ORGO_API_KEY:-}" ]; then
     KEY_TO_WRITE=${ORGO_API_KEY}

--- a/computer-viewer/tests/test-install-agent-plugin.sh
+++ b/computer-viewer/tests/test-install-agent-plugin.sh
@@ -1,0 +1,169 @@
+#!/usr/bin/env bash
+# Offline tests for install-agent-plugin.sh key sources.
+set -euo pipefail
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+INSTALLER=$(CDPATH= cd -- "${SCRIPT_DIR}/.." && pwd)/install-agent-plugin.sh
+PYTHON3=$(command -v python3)
+
+if [ ! -f "${INSTALLER}" ]; then
+  echo "test-install-agent-plugin.sh: installer not found at ${INSTALLER}" >&2
+  exit 1
+fi
+if [ -z "${PYTHON3}" ]; then
+  echo "test-install-agent-plugin.sh: python3 is required" >&2
+  exit 1
+fi
+
+CLEANUP=()
+cleanup() {
+  if [ "${#CLEANUP[@]}" -gt 0 ]; then
+    rm -rf "${CLEANUP[@]}"
+  fi
+}
+trap cleanup EXIT
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+assert_no_leak() {
+  key=$1
+  stdout=$2
+  stderr=$3
+  if printf '%s' "${stdout}" | grep -F -q -- "${key}"; then
+    fail "key leaked on stdout: ${key}"
+  fi
+  if printf '%s' "${stderr}" | grep -F -q -- "${key}"; then
+    fail "key leaked on stderr: ${key}"
+  fi
+}
+
+new_home() {
+  # Must not run in a command substitution: CLEANUP has to be updated here.
+  home=$(mktemp -d)
+  CLEANUP+=("${home}")
+  mkdir -p "${home}/.hermes" "${home}/bin" "${home}/pylib"
+  : > "${home}/.hermes/config.yaml"
+  cat > "${home}/bin/hermes" <<'EOF'
+#!/usr/bin/env bash
+echo "hermes stub: unexpected invocation: $*" >&2
+exit 1
+EOF
+  chmod +x "${home}/bin/hermes"
+  # Minimal PyYAML stand-in so the installer can enable the plugin offline.
+  cat > "${home}/pylib/yaml.py" <<'EOF'
+def safe_load(handle):
+    text = handle.read() if hasattr(handle, "read") else handle
+    if not text or not str(text).strip():
+        return {}
+    return {}
+
+def safe_dump(data, default_flow_style=False, sort_keys=False):
+    enabled = []
+    plugins = data.get("plugins") if isinstance(data, dict) else None
+    if isinstance(plugins, dict):
+        raw = plugins.get("enabled") or []
+        if isinstance(raw, list):
+            enabled = raw
+    lines = ["plugins:\n", "  enabled:\n"]
+    for item in enabled:
+        lines.append("  - %s\n" % item)
+    return "".join(lines)
+EOF
+}
+
+run_installer() {
+  home=$1
+  shift
+  out_file="${home}/stdout.txt"
+  err_file="${home}/stderr.txt"
+  env -u ORGO_API_KEY \
+    HOME="${home}" \
+    PATH="${home}/bin:${PATH}" \
+    HERMES_PYTHON="${PYTHON3}" \
+    PYTHONPATH="${home}/pylib${PYTHONPATH:+:${PYTHONPATH}}" \
+    bash "${INSTALLER}" "$@" > "${out_file}" 2> "${err_file}"
+}
+
+# --- --yes --api-key-stdin ---
+key_stdin="sk_test_abc123"
+new_home
+set +e
+run_installer "${home}" --yes --api-key-stdin <<< "${key_stdin}"
+status=$?
+set -e
+stdout=$(cat "${home}/stdout.txt")
+stderr=$(cat "${home}/stderr.txt")
+if [ "${status}" -ne 0 ]; then
+  printf 'stdout:\n%s\nstderr:\n%s\n' "${stdout}" "${stderr}" >&2
+  fail "stdin case exited ${status}"
+fi
+if ! grep -qx "ORGO_API_KEY=${key_stdin}" "${home}/.hermes/.env"; then
+  printf 'stdout:\n%s\nstderr:\n%s\n.env:\n%s\n' "${stdout}" "${stderr}" "$(cat "${home}/.hermes/.env" 2>/dev/null || true)" >&2
+  fail "stdin case did not write ORGO_API_KEY=${key_stdin}"
+fi
+assert_no_leak "${key_stdin}" "${stdout}" "${stderr}"
+
+# --- --yes --api-key-file ---
+key_file="sk_test_abc123"
+new_home
+keyfile="${home}/api-key"
+printf '%s\n' "${key_file}" > "${keyfile}"
+chmod 600 "${keyfile}"
+set +e
+run_installer "${home}" --yes --api-key-file "${keyfile}"
+status=$?
+set -e
+stdout=$(cat "${home}/stdout.txt")
+stderr=$(cat "${home}/stderr.txt")
+if [ "${status}" -ne 0 ]; then
+  printf 'stdout:\n%s\nstderr:\n%s\n' "${stdout}" "${stderr}" >&2
+  fail "file case exited ${status}"
+fi
+if ! grep -qx "ORGO_API_KEY=${key_file}" "${home}/.hermes/.env"; then
+  printf 'stdout:\n%s\nstderr:\n%s\n.env:\n%s\n' "${stdout}" "${stderr}" "$(cat "${home}/.hermes/.env" 2>/dev/null || true)" >&2
+  fail "file case did not write ORGO_API_KEY=${key_file}"
+fi
+assert_no_leak "${key_file}" "${stdout}" "${stderr}"
+
+# --- --yes --api-key (discouraged, still works) ---
+key_argv="sk_test_argv"
+new_home
+set +e
+run_installer "${home}" --yes --api-key "${key_argv}"
+status=$?
+set -e
+stdout=$(cat "${home}/stdout.txt")
+stderr=$(cat "${home}/stderr.txt")
+if [ "${status}" -ne 0 ]; then
+  printf 'stdout:\n%s\nstderr:\n%s\n' "${stdout}" "${stderr}" >&2
+  fail "argv case exited ${status}"
+fi
+if ! grep -qx "ORGO_API_KEY=${key_argv}" "${home}/.hermes/.env"; then
+  printf 'stdout:\n%s\nstderr:\n%s\n.env:\n%s\n' "${stdout}" "${stderr}" "$(cat "${home}/.hermes/.env" 2>/dev/null || true)" >&2
+  fail "argv case did not write ORGO_API_KEY=${key_argv}"
+fi
+if ! printf '%s' "${stderr}" | grep -F -q "WARNING: --api-key"; then
+  printf 'stderr:\n%s\n' "${stderr}" >&2
+  fail "argv case stderr missing WARNING: --api-key"
+fi
+assert_no_leak "${key_argv}" "${stdout}" "${stderr}"
+
+# --- conflicting flags exit 2 ---
+key_conflict="x"
+new_home
+set +e
+run_installer "${home}" --api-key-stdin --api-key "${key_conflict}"
+status=$?
+set -e
+stdout=$(cat "${home}/stdout.txt")
+stderr=$(cat "${home}/stderr.txt")
+if [ "${status}" -ne 2 ]; then
+  printf 'stdout:\n%s\nstderr:\n%s\n' "${stdout}" "${stderr}" >&2
+  fail "conflict case exited ${status}, expected 2"
+fi
+assert_no_leak "${key_conflict}" "${stdout}" "${stderr}"
+
+echo "test-install-agent-plugin.sh: ok"


### PR DESCRIPTION
Fixes #9.

- New `--api-key-stdin` (one line from stdin) and `--api-key-file PATH` options. The key never appears in argv or shell history.
- `--api-key KEY` keeps working but prints a warning to stderr; usage text lists the safe options first.
- Precedence: stdin > file > argv > `ORGO_API_KEY` env > hidden prompt. More than one explicit flag exits 2.
- Stdin is consumed right after argument parsing so `--yes` with a piped key is not swallowed by the non-tty empty-key fallback.
- `AGENTS.md` and `computer-viewer/README.md` show the stdin form.
- New offline test `computer-viewer/tests/test-install-agent-plugin.sh` (temp HOME, stubbed hermes and yaml) covers all four paths and asserts the key value never reaches stdout or stderr.

Verification: `bash -n` on both scripts, `bash computer-viewer/tests/test-install-agent-plugin.sh` → ok.

🤖 Generated with [Claude Code](https://claude.com/claude-code)