### PR TITLE
computer-viewer: bearer only to the configured origin, sandboxed iframe

### DIFF
--- a/computer-viewer/README.md
+++ b/computer-viewer/README.md
@@ -414,6 +414,10 @@ The pane starts empty until you add a computer:
 | An API key (`sk-…` / `sk_…`, or a similar bare key) | **Find my computers**, then pick one. |
 | `host:port` or a hostname (`macbook.local:6080`) | Probes WebSocket `/websockify`, then `http://host:port/vnc.html`. |
 
+`http://` addresses (web viewer pages and session APIs) are accepted only for
+localhost, LAN, `.local`, and Tailscale hosts. Internet addresses must use
+`https://`.
+
 Power fields (explicit mode, raw URLs, username, scale, quality, …) live
 under **Advanced**.
 
@@ -701,7 +705,7 @@ The address field picks a mode for you. These names only appear under
 | Mode | How it connects | When to use |
 |---|---|---|
 | **WebSocket** (default) | Dynamically loads noVNC 1.7.0 (`RFB`) from jsDelivr, then `esm.sh` if that import throws. | Full controls: scale, view-only, clipboard, Ctrl+Alt+Del, screenshot. |
-| **Iframe** | `<iframe>` pointed at a hosted noVNC page. No CDN. | CSP blocks the noVNC module, you're offline, or you already have `vnc.html`. |
+| **Iframe** | `<iframe>` pointed at a hosted noVNC page. No CDN. Sandboxed; the page cannot read the clipboard unless **Allow this page to read my clipboard** is on for that computer (Advanced, off by default). | CSP blocks the noVNC module, you're offline, or you already have `vnc.html`. |
 | **Session JSON** | `GET` a session document, then WebSocket/RFB as above. | Rotating desktops (paste the API URL or an API key). |
 
 If noVNC cannot be loaded from the CDN (network or CSP), the pane shows

--- a/computer-viewer/agent-plugin/orgo-computer/tests/test_hands.py
+++ b/computer-viewer/agent-plugin/orgo-computer/tests/test_hands.py
@@ -73,9 +73,11 @@ class FakeClient:
         self.router = router
         self.posts = []
         self.gets = []
+        self.get_headers = []
 
     async def get(self, url, headers=None):
         self.gets.append(url)
+        self.get_headers.append(headers or {})
         return self.router("GET", url, None)
 
     async def post(self, url, headers=None, json=None):
@@ -108,6 +110,7 @@ class HandsTests(unittest.TestCase):
         os.environ["ORGO_COMPUTER_ID"] = PIN
         os.environ.pop("ORGO_DEFAULT_COMPUTER_ID", None)
         os.environ.pop("ORGO_API_BASE_URL", None)
+        os.environ.pop("ORGO_ALLOW_INSECURE_HTTP", None)
         tools.bind_context(None)
         tools._PROCESS_LOCKS.clear()
 
@@ -116,6 +119,8 @@ class HandsTests(unittest.TestCase):
         os.environ.pop("HERMES_HOME", None)
         os.environ.pop("ORGO_API_KEY", None)
         os.environ.pop("ORGO_COMPUTER_ID", None)
+        os.environ.pop("ORGO_API_BASE_URL", None)
+        os.environ.pop("ORGO_ALLOW_INSECURE_HTTP", None)
 
     def test_pin_reads_orgo_computer_id(self):
         self.assertEqual(tools._resolve_computer_id(), PIN)
@@ -288,6 +293,100 @@ class HandsTests(unittest.TestCase):
 
     def test_jpeg_size(self):
         self.assertEqual(tools._jpeg_size(TINY_JPEG), (1, 1))
+
+    def _image_headers(self, fake):
+        self.assertGreaterEqual(len(fake.client.get_headers), 2)
+        return fake.client.get_headers[1]
+
+    def test_screenshot_relative_image_sends_bearer(self):
+        def router(method, url, body):
+            if method == "GET" and url.endswith("/screenshot"):
+                return FakeResponse(200, {"success": True, "image": "/api/storage/x.jpg"})
+            return FakeResponse(
+                200, payload=None, content=TINY_JPEG, content_type="image/jpeg"
+            )
+
+        fake = FakeHttpx(router)
+        with patch.object(tools, "_import_httpx", return_value=fake):
+            result = asyncio.run(tools.orgo_computer_screenshot({}))
+        self.assertTrue(result["_multimodal"])
+        auth = self._image_headers(fake).get("Authorization")
+        self.assertTrue(str(auth or "").startswith("Bearer "))
+
+    def test_screenshot_absolute_https_cdn_omits_bearer(self):
+        def router(method, url, body):
+            if method == "GET" and url.endswith("/screenshot"):
+                return FakeResponse(
+                    200, {"success": True, "image": "https://cdn.example/x.jpg"}
+                )
+            if url == "https://cdn.example/x.jpg":
+                return FakeResponse(
+                    200, payload=None, content=TINY_JPEG, content_type="image/jpeg"
+                )
+            self.fail(url)
+
+        fake = FakeHttpx(router)
+        with patch.object(tools, "_import_httpx", return_value=fake):
+            result = asyncio.run(tools.orgo_computer_screenshot({}))
+        self.assertTrue(result["_multimodal"])
+        self.assertNotIn("Authorization", self._image_headers(fake))
+
+    def test_screenshot_absolute_http_cdn_rejected(self):
+        def router(method, url, body):
+            if method == "GET" and url.endswith("/screenshot"):
+                return FakeResponse(
+                    200, {"success": True, "image": "http://cdn.example/x.jpg"}
+                )
+            self.fail(url)
+
+        fake = FakeHttpx(router)
+        with patch.object(tools, "_import_httpx", return_value=fake):
+            raw = asyncio.run(tools.orgo_computer_screenshot({}))
+        self.assertIn("insecure screenshot URL", raw)
+
+    def test_http_api_base_public_host_rejected(self):
+        os.environ["ORGO_API_BASE_URL"] = "http://example.com/api"
+        raw = asyncio.run(tools.orgo_computer_screenshot({}))
+        self.assertIn("must use https://", raw)
+        self.assertIn("ORGO_ALLOW_INSECURE_HTTP", raw)
+
+    def test_http_api_base_loopback_proceeds(self):
+        os.environ["ORGO_API_BASE_URL"] = "http://127.0.0.1:8000/api"
+
+        def router(method, url, body):
+            self.assertTrue(url.startswith("http://127.0.0.1:8000/"))
+            if method == "GET" and url.endswith("/screenshot"):
+                return FakeResponse(200, {"success": True, "image": "/api/storage/x.jpg"})
+            return FakeResponse(
+                200, payload=None, content=TINY_JPEG, content_type="image/jpeg"
+            )
+
+        fake = FakeHttpx(router)
+        with patch.object(tools, "_import_httpx", return_value=fake):
+            result = asyncio.run(tools.orgo_computer_screenshot({}))
+        self.assertTrue(result["_multimodal"])
+
+    def test_http_api_base_public_with_opt_in_proceeds(self):
+        os.environ["ORGO_API_BASE_URL"] = "http://example.com/api"
+        os.environ["ORGO_ALLOW_INSECURE_HTTP"] = "1"
+
+        def router(method, url, body):
+            self.assertTrue(url.startswith("http://example.com/"))
+            if method == "GET" and url.endswith("/screenshot"):
+                return FakeResponse(200, {"success": True, "image": "/api/storage/x.jpg"})
+            return FakeResponse(
+                200, payload=None, content=TINY_JPEG, content_type="image/jpeg"
+            )
+
+        fake = FakeHttpx(router)
+        with patch.object(tools, "_import_httpx", return_value=fake):
+            result = asyncio.run(tools.orgo_computer_screenshot({}))
+        self.assertTrue(result["_multimodal"])
+
+    def test_client_kwargs_disables_redirects(self):
+        fake = FakeHttpx(lambda *a, **k: None)
+        with patch.object(tools, "_import_httpx", return_value=fake):
+            self.assertIs(tools._client_kwargs(5.0)["follow_redirects"], False)
 
     def test_schemas_exist(self):
         self.assertEqual(schemas.ORGO_COMPUTER_CLICK["name"], "orgo_computer_click")

--- a/computer-viewer/agent-plugin/orgo-computer/tools.py
+++ b/computer-viewer/agent-plugin/orgo-computer/tools.py
@@ -138,19 +138,51 @@ def _default_max_steps() -> int:
     return min(MAX_STEPS_LIMIT, max(1, value))
 
 
+def _host_is_loopback(host: str) -> bool:
+    return (host or "").strip().lower().strip("[]") in {"localhost", "127.0.0.1", "::1"}
+
+
+def _insecure_http_opt_in() -> bool:
+    return os.environ.get("ORGO_ALLOW_INSECURE_HTTP", "").strip() == "1"
+
+
+def _url_scheme_allowed(parsed: Any) -> bool:
+    scheme = (parsed.scheme or "").lower()
+    if scheme == "https":
+        return True
+    if scheme == "http" and (
+        _host_is_loopback(parsed.hostname or "") or _insecure_http_opt_in()
+    ):
+        return True
+    return False
+
+
+def _validated_base_url(raw: str, *, setting: str) -> str:
+    text = str(raw or "").strip()
+    parsed = urlparse(text)
+    if _url_scheme_allowed(parsed):
+        return text
+    raise OrgoAgentRequestError(
+        f"{setting} must use https:// (set ORGO_ALLOW_INSECURE_HTTP=1 only for local development)."
+    )
+
+
 def _agent_endpoint() -> str:
     explicit = os.environ.get("ORGO_AGENT_API_URL", "").strip()
     if explicit:
-        return explicit
+        return _validated_base_url(explicit, setting="ORGO_AGENT_API_URL")
 
-    base = os.environ.get("ORGO_API_BASE_URL", DEFAULT_ORGO_API_BASE).strip().rstrip("/")
+    base = _api_base()
     if base.endswith("/v1"):
         return f"{base}/chat/completions"
     return f"{base}/v1/chat/completions"
 
 
 def _api_base() -> str:
-    return os.environ.get("ORGO_API_BASE_URL", DEFAULT_ORGO_API_BASE).strip().rstrip("/")
+    return _validated_base_url(
+        os.environ.get("ORGO_API_BASE_URL", DEFAULT_ORGO_API_BASE).strip().rstrip("/"),
+        setting="ORGO_API_BASE_URL",
+    )
 
 
 def _api_key() -> str:
@@ -1285,6 +1317,7 @@ async def _run_orgo_agent(
     computer_id = _require_computer_id()
     timeout_seconds = _resolve_timeout_seconds()
     lock_wait_seconds = _resolve_lock_wait_seconds()
+    endpoint = _agent_endpoint()
     httpx = _import_httpx()
     request_body = {
         "model": model,
@@ -1294,12 +1327,10 @@ async def _run_orgo_agent(
     }
 
     async with _ComputerRunLock(computer_id, lock_wait_seconds):
-        active_client = httpx.AsyncClient(
-            timeout=httpx.Timeout(timeout_seconds, connect=min(30.0, timeout_seconds))
-        )
+        active_client = httpx.AsyncClient(**_client_kwargs(timeout_seconds))
         try:
             response = await active_client.post(
-                _agent_endpoint(),
+                endpoint,
                 headers=_auth_headers(api_key),
                 json=request_body,
             )
@@ -1349,13 +1380,11 @@ async def _run_bash(command: str) -> dict[str, Any]:
     api_key = _require_api_key()
     computer_id = _require_computer_id()
     timeout_seconds = _resolve_bash_timeout()
-    httpx = _import_httpx()
     url = f"{_api_base()}/computers/{quote(computer_id, safe='')}/bash"
+    httpx = _import_httpx()
     # Give Orgo a chance to return before the client times out.
     client_timeout = float(timeout_seconds) + 15.0
-    active_client = httpx.AsyncClient(
-        timeout=httpx.Timeout(client_timeout, connect=min(30.0, client_timeout))
-    )
+    active_client = httpx.AsyncClient(**_client_kwargs(client_timeout))
     try:
         response = await active_client.post(
             url,
@@ -1423,20 +1452,27 @@ def _refuse_if_run_locked() -> None:
         raise OrgoAgentRequestError(LOCK_BUSY_ERROR)
 
 
+def _client_kwargs(timeout: float) -> dict[str, Any]:
+    httpx = _import_httpx()
+    return {
+        "timeout": httpx.Timeout(timeout, connect=min(30.0, timeout)),
+        "follow_redirects": False,
+    }
+
+
 async def _http_client(timeout: float) -> Any:
     httpx = _import_httpx()
-    return httpx, httpx.AsyncClient(
-        timeout=httpx.Timeout(timeout, connect=min(30.0, timeout))
-    )
+    return httpx, httpx.AsyncClient(**_client_kwargs(timeout))
 
 
 async def _take_screenshot() -> dict[str, Any]:
     api_key = _require_api_key()
     computer_id = _require_computer_id()
+    base = _api_base()
     httpx, client = await _http_client(30.0)
     try:
         meta = await client.get(
-            f"{_api_base()}/computers/{quote(computer_id, safe='')}/screenshot",
+            f"{base}/computers/{quote(computer_id, safe='')}/screenshot",
             headers=_auth_headers(api_key),
         )
         payload = _read_json(meta, kind="screenshot")
@@ -1448,7 +1484,14 @@ async def _take_screenshot() -> dict[str, Any]:
         if not isinstance(image_path, str) or not image_path.strip():
             raise OrgoAgentRequestError("Orgo screenshot returned no image.")
         image_url = _absolute_image_url(image_path)
-        headers = {"Authorization": f"Bearer {api_key}", "Accept": "image/*"}
+        parsed_image = urlparse(image_url)
+        image_origin = f"{parsed_image.scheme}://{parsed_image.netloc}"
+        if image_origin == _image_origin():
+            headers = {"Authorization": f"Bearer {api_key}", "Accept": "image/*"}
+        else:
+            if not _url_scheme_allowed(parsed_image):
+                raise OrgoAgentRequestError("Orgo returned an insecure screenshot URL.")
+            headers = {"Accept": "image/*"}
         image_resp = await client.get(image_url, headers=headers)
         if not image_resp.is_success:
             _raise_hands_http(image_resp.status_code, None, "screenshot")
@@ -1514,10 +1557,11 @@ async def _post_hands(path: str, body: dict[str, Any], action: str) -> dict[str,
     _refuse_if_run_locked()
     api_key = _require_api_key()
     computer_id = _require_computer_id()
+    url = f"{_api_base()}/computers/{quote(computer_id, safe='')}/{path}"
     httpx, client = await _http_client(30.0)
     try:
         response = await client.post(
-            f"{_api_base()}/computers/{quote(computer_id, safe='')}/{path}",
+            url,
             headers=_auth_headers(api_key),
             json=body,
         )

--- a/computer-viewer/plugin.js
+++ b/computer-viewer/plugin.js
@@ -111,6 +111,14 @@ const ERRORS = {
   unreachable: {
     title: "Can't reach the computer",
     body: 'Gave up after 5 attempts. Check that the endpoint is up ({wsUrl}).'
+  },
+  'unsafe-origin': {
+    title: 'Refused to send API key',
+    body: 'Refused to send your API key to {origin}. Only the configured API address gets it.'
+  },
+  redirect: {
+    title: 'Redirect blocked',
+    body: 'The API address redirected elsewhere; refusing to follow with your key.'
   }
 }
 
@@ -286,6 +294,8 @@ const DEFAULT_ENDPOINT_NAME = 'My computer'
 const ADDRESS_EMPTY_HELP =
   "Works with a wss:// address, a noVNC web page, a cloud API key, or just host:port — paste it and I'll figure out which."
 const ADDRESS_INVALID_LINE = "Hmm — that doesn't look like an address or key."
+const HTTP_PUBLIC_ADDRESS_LINE =
+  'Use https:// for internet addresses. http:// only works for localhost, LAN, .local and Tailscale hosts.'
 const SK_KEY_RE = /^sk[_-][A-Za-z0-9_-]{8,}$/
 
 function isDefaultishName(name) {
@@ -394,20 +404,38 @@ function classifyAddress(raw) {
     }
   }
   if (lower.startsWith('http://') || lower.startsWith('https://')) {
+    let parsed
     try {
-      const parsed = new URL(address)
+      parsed = new URL(address)
       if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
         return { kind: 'invalid', line: ADDRESS_INVALID_LINE, connectEnabled: false, patch: { probe: false } }
       }
     } catch {
       return { kind: 'invalid', line: ADDRESS_INVALID_LINE, connectEnabled: false, patch: { probe: false } }
     }
+    const insecurePublic = parsed.protocol === 'http:' && !isPrivateWsHost(parsed.hostname)
     if (isNovncPageUrl(address)) {
+      if (insecurePublic) {
+        return {
+          kind: 'invalid',
+          line: HTTP_PUBLIC_ADDRESS_LINE,
+          connectEnabled: false,
+          patch: { probe: false }
+        }
+      }
       return {
         kind: 'iframe',
-        line: '✓ Web viewer page — will be embedded',
+        line: `✓ Web viewer page at ${parsed.origin} — will be embedded`,
         connectEnabled: true,
         patch: { mode: 'iframe', iframeUrl: address, probe: false }
+      }
+    }
+    if (insecurePublic) {
+      return {
+        kind: 'invalid',
+        line: HTTP_PUBLIC_ADDRESS_LINE,
+        connectEnabled: false,
+        patch: { probe: false }
       }
     }
     return {
@@ -485,7 +513,8 @@ function blankEndpoint() {
     compressionLevel: 2,
     hiperfEnabled: false,
     hiperfUrl: '',
-    hiperfToken: ''
+    hiperfToken: '',
+    allowClipboard: false
   }
 }
 
@@ -512,7 +541,8 @@ function normalizeEndpoint(raw) {
     compressionLevel: clampInt(raw.compressionLevel, 0, 9, 2),
     hiperfEnabled: raw.hiperfEnabled === true,
     hiperfUrl: String(raw.hiperfUrl || ''),
-    hiperfToken: String(raw.hiperfToken || '')
+    hiperfToken: String(raw.hiperfToken || ''),
+    allowClipboard: raw.allowClipboard === true
   }
 }
 
@@ -531,7 +561,8 @@ function fingerprint(endpoint) {
     endpoint.probe ? '1' : '0',
     endpoint.qualityLevel,
     endpoint.compressionLevel,
-    endpoint.autoConnect ? '1' : '0'
+    endpoint.autoConnect ? '1' : '0',
+    endpoint.allowClipboard ? '1' : '0'
   ].join('\0')
 }
 
@@ -560,6 +591,43 @@ function orgoApiOrigin(sessionUrl) {
     /* not an absolute URL */
   }
   return 'https://www.orgo.ai'
+}
+
+function credentialTargetAllowed(url, sessionUrl) {
+  try {
+    const parsed = new URL(String(url || '').trim())
+    if (parsed.origin !== orgoApiOrigin(sessionUrl)) return false
+    if (parsed.protocol === 'https:') return true
+    if (parsed.protocol === 'http:' && isPrivateWsHost(parsed.hostname)) return true
+    return false
+  } catch {
+    return false
+  }
+}
+
+function credentialError(status, origin) {
+  return Object.assign(new Error(status), { status, origin })
+}
+
+async function authFetch(url, { bearer, sessionUrl, signal, accept } = {}) {
+  let origin = ''
+  try {
+    origin = new URL(String(url || '').trim()).origin
+  } catch {
+    origin = ''
+  }
+  if (!credentialTargetAllowed(url, sessionUrl)) {
+    throw credentialError('unsafe-origin', origin)
+  }
+  const headers = {
+    Accept: accept || 'application/json',
+    Authorization: 'Bearer ' + bearer
+  }
+  const response = await fetch(url, { headers, signal, redirect: 'manual' })
+  const redirected =
+    response.type === 'opaqueredirect' || (response.status >= 300 && response.status < 400)
+  if (redirected) throw credentialError('redirect', origin)
+  return response
 }
 
 function orgoShapeKeys(value) {
@@ -695,11 +763,16 @@ function orgoDiscoverError(kind) {
   return err
 }
 
-async function orgoFetchJson(url, headers) {
+function isCredentialError(error) {
+  return Boolean(error && (error.status === 'unsafe-origin' || error.status === 'redirect'))
+}
+
+async function orgoFetchJson(url, { bearer, sessionUrl }) {
   let response
   try {
-    response = await fetch(url, { headers })
-  } catch {
+    response = await authFetch(url, { bearer, sessionUrl })
+  } catch (error) {
+    if (isCredentialError(error)) throw error
     throw orgoDiscoverError('network')
   }
   if (response.status === 401 || response.status === 403) throw orgoDiscoverError('auth')
@@ -711,11 +784,12 @@ async function orgoFetchJson(url, headers) {
   }
 }
 
-async function orgoFetchJsonOptional(url, headers) {
+async function orgoFetchJsonOptional(url, { bearer, sessionUrl }) {
   let response
   try {
-    response = await fetch(url, { headers })
-  } catch {
+    response = await authFetch(url, { bearer, sessionUrl })
+  } catch (error) {
+    if (isCredentialError(error)) throw error
     return { ok: false, status: 'network', body: null }
   }
   let body = null
@@ -734,8 +808,7 @@ function pushOrgoComputers(computers, list, workspaceName) {
 }
 
 async function discoverOrgoComputers(origin, bearer, sessionUrl) {
-  const headers = { Accept: 'application/json', Authorization: `Bearer ${bearer}` }
-  const listed = await orgoFetchJson(`${origin}/api/workspaces`, headers)
+  const listed = await orgoFetchJson(`${origin}/api/workspaces`, { bearer, sessionUrl })
   const workspaces = unwrapWorkspaceList(listed.body)
   const workspaceCount = workspaces.length
   const computers = []
@@ -769,7 +842,10 @@ async function discoverOrgoComputers(origin, bearer, sessionUrl) {
   const details = await Promise.all(
     detailSlice.map(async ws => {
       const id = String(ws.id).trim()
-      const result = await orgoFetchJsonOptional(`${origin}/api/workspaces/${encodeURIComponent(id)}`, headers)
+      const result = await orgoFetchJsonOptional(`${origin}/api/workspaces/${encodeURIComponent(id)}`, {
+        bearer,
+        sessionUrl
+      })
       return { ws, result }
     })
   )
@@ -801,7 +877,10 @@ async function discoverOrgoComputers(origin, bearer, sessionUrl) {
     const uuid = uuidFromText(sessionUrl)
     if (uuid) {
       uuidFallback = true
-      const result = await orgoFetchJsonOptional(`${origin}/api/computers/${encodeURIComponent(uuid)}`, headers)
+      const result = await orgoFetchJsonOptional(`${origin}/api/computers/${encodeURIComponent(uuid)}`, {
+        bearer,
+        sessionUrl
+      })
       uuidFallbackStatus = result.status
       const record = unwrapSessionBody(result.body)
       const id = record && typeof record.id === 'string' ? record.id.trim() : ''
@@ -874,9 +953,9 @@ function phaseLine(state) {
     case 'loading-novnc':
       return 'Loading viewer…'
     case 'connecting':
-      return 'Connecting…'
+      return state.detail ? `Connecting to ${state.detail}…` : 'Connecting…'
     case 'connected':
-      return 'Connected'
+      return state.detail ? `Connected · ${state.detail}` : 'Connected'
     case 'disconnected':
       return state.detail || 'Disconnected'
     case 'error':
@@ -1305,11 +1384,20 @@ function ensureSurfaceEl() {
   return elNode
 }
 
+function iframePolicy(endpoint) {
+  const allowClipboard = Boolean(endpoint && endpoint.allowClipboard)
+  return {
+    sandbox: 'allow-scripts allow-same-origin allow-forms',
+    allow: allowClipboard
+      ? 'fullscreen; clipboard-write; clipboard-read'
+      : 'fullscreen; clipboard-write'
+  }
+}
+
 function ensureIframeEl() {
   if (engine.iframeEl) return engine.iframeEl
   const frame = document.createElement('iframe')
   frame.setAttribute('title', 'Remote computer')
-  frame.setAttribute('allow', 'clipboard-read; clipboard-write; fullscreen')
   frame.style.width = '100%'
   frame.style.height = '100%'
   frame.style.border = '0'
@@ -1466,15 +1554,18 @@ function teardownIframe(blank) {
   if (blank) engine.iframeEl.src = 'about:blank'
 }
 
-async function fetchOrgoVncPassword(origin, computerId, headers, signal, gen) {
+async function fetchOrgoVncPassword(origin, computerId, bearer, sessionUrl, signal, gen) {
   let response
   try {
-    response = await fetch(`${origin}/api/computers/${encodeURIComponent(computerId)}/vnc-password`, {
-      headers,
-      signal
-    })
+    const url = `${origin}/api/computers/${encodeURIComponent(computerId)}/vnc-password`
+    if (bearer) {
+      response = await authFetch(url, { bearer, sessionUrl, signal })
+    } else {
+      response = await fetch(url, { headers: { Accept: 'application/json' }, signal })
+    }
   } catch (error) {
     if (error && error.name === 'AbortError') throw error
+    if (isCredentialError(error)) throw error
     return ''
   }
   if (!still(gen)) {
@@ -1494,16 +1585,42 @@ async function fetchOrgoVncPassword(origin, computerId, headers, signal, gen) {
   return raw == null ? '' : String(raw)
 }
 
+function credentialErrorDetail(error) {
+  if (!error) return null
+  if (error.status === 'unsafe-origin') {
+    const origin = error.origin || 'an unexpected address'
+    return {
+      code: 'unsafe-origin',
+      detail: ERRORS['unsafe-origin'].body.replace('{origin}', origin)
+    }
+  }
+  if (error.status === 'redirect') {
+    return { code: 'redirect', detail: ERRORS.redirect.body }
+  }
+  return null
+}
+
 async function fetchSession(endpoint, gen) {
   const ac = new AbortController()
   engine.fetchAbort = ac
-  const headers = { Accept: 'application/json' }
-  if (endpoint.sessionBearer) headers.Authorization = `Bearer ${endpoint.sessionBearer}`
+  const bearer = String(endpoint.sessionBearer || '')
   let response
   try {
-    response = await fetch(endpoint.sessionUrl, { headers, signal: ac.signal })
+    if (bearer) {
+      response = await authFetch(endpoint.sessionUrl, {
+        bearer,
+        sessionUrl: endpoint.sessionUrl,
+        signal: ac.signal
+      })
+    } else {
+      response = await fetch(endpoint.sessionUrl, {
+        headers: { Accept: 'application/json' },
+        signal: ac.signal
+      })
+    }
   } catch (error) {
     if (error && error.name === 'AbortError') throw error
+    if (isCredentialError(error)) throw error
     const wrapped = new Error('network')
     wrapped.status = 'network'
     throw wrapped
@@ -1550,7 +1667,8 @@ async function fetchSession(endpoint, gen) {
           password = await fetchOrgoVncPassword(
             orgoApiOrigin(endpoint.sessionUrl),
             computerId,
-            headers,
+            bearer,
+            endpoint.sessionUrl,
             ac.signal,
             gen
           )
@@ -1608,13 +1726,33 @@ async function connectIframe(endpoint, gen) {
     setError('unconfigured', ERRORS.unconfigured.body)
     return
   }
-  patchState({ phase: 'connecting', code: null, detail: null, desktopName: null, fbW: 0, fbH: 0 })
+  let origin = ''
+  try {
+    origin = new URL(String(endpoint.iframeUrl).trim()).origin
+  } catch {
+    origin = String(endpoint.iframeUrl || '')
+  }
+  const policy = iframePolicy(endpoint)
+  if (engine.iframeEl) {
+    const existing = engine.iframeEl
+    if (
+      existing.getAttribute('sandbox') !== policy.sandbox ||
+      existing.getAttribute('allow') !== policy.allow
+    ) {
+      existing.onload = null
+      if (existing.parentNode) existing.parentNode.removeChild(existing)
+      engine.iframeEl = null
+    }
+  }
+  patchState({ phase: 'connecting', code: null, detail: origin, desktopName: null, fbW: 0, fbH: 0 })
   const frame = ensureIframeEl()
+  frame.setAttribute('sandbox', policy.sandbox)
+  frame.setAttribute('allow', policy.allow)
   frame.onload = () => {
     if (!still(gen)) return
     if (!frame.src || frame.src === 'about:blank') return
     engine.reconnectAttempt = 0
-    patchState({ phase: 'connected', code: null, detail: null })
+    patchState({ phase: 'connected', code: null, detail: origin })
     bumpPlace()
   }
   if (frame.getAttribute('src') === endpoint.iframeUrl) frame.src = 'about:blank'
@@ -1686,6 +1824,11 @@ async function connect(endpoint) {
     } catch (error) {
       if (!still(gen)) return
       if (error && error.name === 'AbortError') return
+      const credential = credentialErrorDetail(error)
+      if (credential) {
+        setError(credential.code, credential.detail)
+        return
+      }
       if (error && error.sessionDetail) {
         setError('session-failed', error.sessionDetail)
         return
@@ -3191,7 +3334,9 @@ function OrgoComputerFinder({ bearer, sessionUrl, onPick }) {
       }
     } catch (err) {
       if (gen !== genRef.current) return
-      if (err && err.kind === 'auth') setError('This API key was rejected.')
+      const credential = credentialErrorDetail(err)
+      if (credential) setError(credential.detail)
+      else if (err && err.kind === 'auth') setError('This API key was rejected.')
       else setError("Couldn't reach the API from the app — set the API address in Advanced.")
     } finally {
       if (gen === genRef.current) setLoading(false)
@@ -3526,6 +3671,31 @@ function EndpointEditor({
                 onChange: event => touchAdvanced({ username: event.target.value })
               })
             ),
+            draft.mode === 'iframe'
+              ? el(
+                  'div',
+                  { className: 'grid gap-1' },
+                  el(
+                    'div',
+                    { className: 'flex items-center justify-between gap-3' },
+                    el(
+                      'span',
+                      { className: 'text-[0.7rem] text-(--ui-text-secondary)' },
+                      'Allow this page to read my clipboard'
+                    ),
+                    el(Switch, {
+                      size: 'xs',
+                      checked: draft.allowClipboard === true,
+                      onCheckedChange: value => touchAdvanced({ allowClipboard: value })
+                    })
+                  ),
+                  el(
+                    'p',
+                    { className: 'text-[0.64rem] leading-4 text-(--ui-text-quaternary)' },
+                    'Off by default. Only turn on for pages you control.'
+                  )
+                )
+              : null,
             el(
               'div',
               { className: 'flex items-center justify-between gap-3' },

--- a/computer-viewer/plugin.test.mjs
+++ b/computer-viewer/plugin.test.mjs
@@ -1,0 +1,300 @@
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import test from 'node:test'
+import vm from 'node:vm'
+
+const pluginPath = new URL('./plugin.js', import.meta.url)
+
+const SDK_COMPONENTS = [
+  'Badge',
+  'Button',
+  'ConfirmDialog',
+  'CopyButton',
+  'Dialog',
+  'DialogContent',
+  'DialogDescription',
+  'DialogFooter',
+  'DialogHeader',
+  'DialogTitle',
+  'DropdownMenu',
+  'DropdownMenuContent',
+  'DropdownMenuItem',
+  'DropdownMenuSeparator',
+  'DropdownMenuTrigger',
+  'EmptyState',
+  'ErrorState',
+  'Input',
+  'Loader',
+  'SegmentedControl',
+  'Select',
+  'SelectContent',
+  'SelectItem',
+  'SelectTrigger',
+  'SelectValue',
+  'Separator',
+  'StatusDot',
+  'Switch',
+  'Tip'
+]
+
+const PRELUDE = `
+const PALETTE_AREA = 'palette'
+const KEYBINDS_AREA = 'keybinds'
+const PANES_AREA = 'panes'
+const STATUSBAR_AREAS = { right: 'right' }
+const host = globalThis.__host
+const HermesSdk = globalThis.HermesSdk || {}
+const atom = globalThis.__atom
+const cn = (...xs) => xs.filter(Boolean).join(' ')
+const useValue = store => (store && typeof store.get === 'function' ? store.get() : null)
+const icons = new Proxy({}, { get: () => () => null })
+${SDK_COMPONENTS.map(name => `const ${name} = '${name}'`).join('\n')}
+const Fragment = 'Fragment'
+const useEffect = () => {}
+const useLayoutEffect = () => {}
+const useMemo = fn => fn()
+const useRef = value => ({ current: value })
+const useState = value => [typeof value === 'function' ? value() : value, () => {}]
+const jsx = (type, props, key) => ({ type, props, key })
+const jsxs = jsx
+`
+
+function atom(initial) {
+  let value = initial
+  const listeners = new Set()
+  return {
+    get: () => value,
+    set: next => {
+      value = next
+      for (const fn of listeners) fn(value)
+    },
+    listen: fn => {
+      listeners.add(fn)
+      return () => listeners.delete(fn)
+    }
+  }
+}
+
+function loadPlugin({ fetchImpl } = {}) {
+  const fetches = []
+  const fetch =
+    fetchImpl ||
+    (async (url, init) => {
+      fetches.push({ url, init })
+      return { ok: true, status: 200, type: 'basic', json: async () => ({}) }
+    })
+
+  const context = {
+    AbortController,
+    Array,
+    ArrayBuffer,
+    Boolean,
+    DataView,
+    Date,
+    Error,
+    Float32Array,
+    Float64Array,
+    Infinity,
+    Int16Array,
+    Int32Array,
+    Int8Array,
+    JSON,
+    Map,
+    Math,
+    NaN,
+    Number,
+    Object,
+    Promise,
+    Proxy,
+    RangeError,
+    Reflect,
+    RegExp,
+    Set,
+    String,
+    Symbol,
+    SyntaxError,
+    TextDecoder,
+    TextEncoder,
+    TypeError,
+    URIError,
+    URL,
+    URLSearchParams,
+    Uint16Array,
+    Uint32Array,
+    Uint8Array,
+    WeakMap,
+    WeakSet,
+    atob: typeof atob === 'function' ? atob : undefined,
+    btoa: typeof btoa === 'function' ? btoa : undefined,
+    clearInterval,
+    clearTimeout,
+    console,
+    decodeURI,
+    decodeURIComponent,
+    encodeURI,
+    encodeURIComponent,
+    fetch,
+    isFinite,
+    isNaN,
+    parseFloat,
+    parseInt,
+    queueMicrotask,
+    setInterval,
+    setTimeout,
+    undefined,
+    document: {
+      body: { classList: { add() {}, contains: () => false, remove() {} } },
+      createElement: () => ({
+        setAttribute() {},
+        getAttribute: () => null,
+        style: {},
+        addEventListener() {}
+      }),
+      querySelector: () => null,
+      querySelectorAll: () => []
+    },
+    localStorage: {
+      getItem: () => null,
+      setItem() {},
+      removeItem() {},
+      clear() {}
+    },
+    navigator: {
+      userAgent: 'test',
+      clipboard: { readText: async () => '', writeText: async () => {} }
+    },
+    MutationObserver: class {
+      observe() {}
+      disconnect() {}
+      takeRecords() {
+        return []
+      }
+    },
+    requestAnimationFrame: cb => setTimeout(cb, 0),
+    cancelAnimationFrame: id => clearTimeout(id),
+    HermesSdk: {},
+    __host: {
+      state: {},
+      paneVisibility: () => ({ get: () => false, listen: () => () => undefined })
+    },
+    __atom: atom
+  }
+  context.window = context
+  context.globalThis = context
+  context.self = context
+
+  const source = PRELUDE +
+    fs
+      .readFileSync(pluginPath, 'utf8')
+      .replace(/import\s+\{[\s\S]*?\}\s+from '@hermes\/plugin-sdk'\n/, '')
+      .replace(/import \* as HermesSdk from '@hermes\/plugin-sdk'\n/, '')
+      .replace(
+        /import \{ Fragment, useEffect, useLayoutEffect, useMemo, useRef, useState \} from 'react'\n/,
+        ''
+      )
+      .replace(/import \{ jsx, jsxs \} from 'react\/jsx-runtime'\n/, '')
+      .replace('export default {', 'globalThis.__plugin = {')
+      .concat(
+        '\nglobalThis.__t = { credentialTargetAllowed, iframePolicy, classifyAddress, orgoApiOrigin, authFetch }\n'
+      )
+
+  vm.runInNewContext(source, vm.createContext(context), { filename: pluginPath.pathname })
+  return { t: context.__t, fetches, context }
+}
+
+test('credentialTargetAllowed accepts the configured https origin only', () => {
+  const { t } = loadPlugin()
+  const session = 'https://www.orgo.ai/api/session'
+  assert.equal(t.credentialTargetAllowed('https://www.orgo.ai/api/computers/1', session), true)
+  assert.equal(t.credentialTargetAllowed('https://evil.example/steal', session), false)
+  assert.equal(
+    t.credentialTargetAllowed('http://example.com/api/x', 'http://example.com/api'),
+    false
+  )
+  assert.equal(
+    t.credentialTargetAllowed('http://192.168.1.5:8000/x', 'http://192.168.1.5:8000/api'),
+    true
+  )
+  assert.equal(
+    t.credentialTargetAllowed('http://localhost:8000/x', 'http://localhost:8000/api'),
+    true
+  )
+  assert.equal(t.credentialTargetAllowed('not a url', session), false)
+})
+
+test('classifyAddress rejects public http and names iframe origins', () => {
+  const { t } = loadPlugin()
+  const publicVnc = t.classifyAddress('http://1.2.3.4:6080/vnc.html')
+  assert.equal(publicVnc.kind, 'invalid')
+  assert.equal(publicVnc.connectEnabled, false)
+
+  const httpsVnc = t.classifyAddress('https://x.example/vnc.html')
+  assert.equal(httpsVnc.kind, 'iframe')
+  assert.match(httpsVnc.line, /https:\/\/x\.example/)
+
+  const lanVnc = t.classifyAddress('http://192.168.1.5:6080/')
+  assert.equal(lanVnc.kind, 'iframe')
+  assert.equal(lanVnc.connectEnabled, true)
+
+  const publicSession = t.classifyAddress('http://1.2.3.4/api/session')
+  assert.equal(publicSession.kind, 'invalid')
+
+  const orgo = t.classifyAddress('https://www.orgo.ai/api/session')
+  assert.equal(orgo.kind, 'session-json')
+})
+
+test('iframePolicy sandboxes the viewer and keeps clipboard-read opt-in', () => {
+  const { t } = loadPlugin()
+  const off = t.iframePolicy({})
+  assert.equal(off.sandbox, 'allow-scripts allow-same-origin allow-forms')
+  assert.equal(off.allow.includes('clipboard-read'), false)
+  assert.equal(off.allow, 'fullscreen; clipboard-write')
+
+  const on = t.iframePolicy({ allowClipboard: true })
+  assert.equal(on.sandbox, 'allow-scripts allow-same-origin allow-forms')
+  assert.match(on.allow, /clipboard-read/)
+})
+
+test('authFetch refuses off-origin targets without calling fetch', async () => {
+  const { t, fetches } = loadPlugin()
+  await assert.rejects(
+    () =>
+      t.authFetch('https://evil.example/api', {
+        bearer: 'secret',
+        sessionUrl: 'https://www.orgo.ai/api/session'
+      }),
+    err => err && err.status === 'unsafe-origin'
+  )
+  assert.equal(fetches.length, 0)
+})
+
+test('authFetch throws redirect on opaqueredirect and never follows', async () => {
+  const { t } = loadPlugin({
+    fetchImpl: async () => ({ type: 'opaqueredirect', status: 0 })
+  })
+  await assert.rejects(
+    () =>
+      t.authFetch('https://www.orgo.ai/api/session', {
+        bearer: 'secret',
+        sessionUrl: 'https://www.orgo.ai/api/session'
+      }),
+    err => err && err.status === 'redirect'
+  )
+})
+
+test('authFetch sends the bearer with redirect: manual on an allowed call', async () => {
+  let seen
+  const { t } = loadPlugin({
+    fetchImpl: async (url, init) => {
+      seen = { url, init }
+      return { ok: true, status: 200, type: 'basic' }
+    }
+  })
+  const response = await t.authFetch('https://www.orgo.ai/api/computers/1', {
+    bearer: 'secret-token',
+    sessionUrl: 'https://www.orgo.ai/api/session'
+  })
+  assert.equal(response.status, 200)
+  assert.equal(seen.init.redirect, 'manual')
+  assert.equal(seen.init.headers.Authorization, 'Bearer secret-token')
+})


### PR DESCRIPTION
Fixes #6. Fixes #8.

**Desktop plugin (`computer-viewer/plugin.js`)**
- New `credentialTargetAllowed()` + `authFetch()`: every request carrying the API key checks that the URL origin equals the configured API origin, requires `https://` unless the host is localhost/LAN/`.local`/Tailscale, and uses `redirect: 'manual'` so a key never follows a redirect. Session fetch, Orgo discovery, and VNC-password lookup all go through it.
- Public `http://` session or viewer-page addresses are rejected at paste time with a clear line.
- Refusals surface in the pane as "Refused to send API key" / "Redirect blocked" instead of a generic network error.
- Viewer iframe: `sandbox="allow-scripts allow-same-origin allow-forms"`, `allow="fullscreen; clipboard-write"`. Clipboard read is an Advanced per-computer switch, off by default. The iframe is recreated when the policy changes so attributes always apply.
- Status line shows the embedded origin while connecting/connected.

**Agent plugin (`orgo-computer/tools.py`)**
- `ORGO_API_BASE_URL` / `ORGO_AGENT_API_URL` must be `https://` unless loopback or `ORGO_ALLOW_INSECURE_HTTP=1`. Validated at tool run time, never at import.
- Screenshot image URLs on a foreign origin are fetched without `Authorization` and must be https.
- All httpx clients set `follow_redirects=False` via one `_client_kwargs()` helper.

**Tests**
- New `computer-viewer/plugin.test.mjs` (6 cases, vm-loaded like bubble-mode's test).
- 7 new cases in `tests/test_hands.py` (21 total).

Verification: `node --check`, `node --test` (13 pass), `python3 -m unittest` (21 pass), `hermes plugins doctor --ci` OK, ASCII check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)