### PR TITLE
host scripts: bind websockify and the HD agent to Tailscale or loopback

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -22,8 +22,18 @@ within a few days.
 
 ## Scope notes
 
-- The VNC bridges (`connect-*` scripts) bind to **loopback only**; exposing
-  them to a network is outside supported configuration.
+- The VNC server itself (port 5900) is loopback-only. The websockify
+  bridge (6080) and HD agent (6090) are network listeners. Default bind:
+  the Tailscale interface when Tailscale is up, otherwise loopback.
+  `CV_BIND=0.0.0.0` exposes them on every interface and is supported only
+  on a trusted LAN. Transport is plaintext `ws://`: confidentiality and
+  peer authentication come from the tailnet (WireGuard) or an SSH tunnel,
+  not from the bridge. No TLS/`wss` mode exists. The HD token travels in
+  the WebSocket query string because the browser WebSocket API cannot set
+  headers; anyone who can read the wire can read it — keep it on the
+  tailnet or tunnel. The VNC password is 8 characters by protocol
+  (classic DES auth); treat it as a second factor, not the boundary. The
+  desktop plugin refuses `ws://` to public hosts.
 - HD mode tokens and Orgo API keys are stored locally by design
   (`.env` / plugin storage, `0600`). They are never transmitted anywhere
   except to the endpoint you configure.

--- a/computer-viewer/README.md
+++ b/computer-viewer/README.md
@@ -112,15 +112,19 @@ The plugin talks to two kinds of computer:
   TLS-fronted VPS, a Docker desktop box). Detection is automatic; you do not
   pick a mode.
 - **Local** — a Mac, Windows PC, or Linux box on your LAN or Tailscale. Run
-  the one-paste script **on that machine**. It binds VNC to localhost and
-  publishes a WebSocket on port **6080**. Paste the printed
-  `ws://.../websockify` address into **Computer address**, plus the VNC
+  the one-paste script **on that machine**. VNC stays on localhost:5900.
+  websockify (:6080) and the HD agent (:6090) bind the Tailscale IPv4 when
+  Tailscale is up, otherwise loopback. `CV_BIND=0.0.0.0` (Windows: `-Bind
+  0.0.0.0`) exposes them on every interface — trusted LAN only. Paste the
+  printed `ws://...` address into **Computer address**, plus the VNC
   password (and on a Mac, your username).
 
 The scripts are idempotent and print the exact paste address when they
-finish. Tailscale MagicDNS names and `.local` hostnames both work. websockify
-is pinned (`websockify==0.13.0` on Mac/Windows; distro package on Linux).
-LAN / Tailscale only — never the public internet.
+finish. On a Tailscale bind they print the `100.x` address and the
+MagicDNS name; on loopback they print an SSH tunnel recipe first.
+websockify is pinned (`websockify==0.13.0` on Mac/Windows; distro package
+on Linux). Transport is plaintext `ws://` — the tailnet or an SSH tunnel
+is the boundary, never the public internet.
 
 ### macOS
 
@@ -321,10 +325,16 @@ stream), paste the printed token, turn on HD.
 
 ## Security
 
-- **Never expose VNC or the websocket port to the internet.** These scripts
-  bind VNC (`:5900`) to localhost and only publish websockify (`:6080`) on
-  the private network. Use Tailscale or LAN. No router port-forward, no
-  public IP, no `0.0.0.0` on 5900.
+- **Never expose VNC or the websocket ports to the internet.** VNC (`:5900`)
+  is loopback-only. websockify (`:6080`) and the HD agent (`:6090`) are
+  network listeners: Tailscale IPv4 when present, otherwise loopback.
+  `CV_BIND=0.0.0.0` binds every interface and is supported only on a
+  trusted LAN. No router port-forward, no public IP. Transport is
+  plaintext `ws://` — confidentiality comes from the tailnet (WireGuard)
+  or an SSH tunnel, not from the bridge. No TLS/`wss` mode exists. The HD
+  token is in the WebSocket query string (the browser API cannot set
+  headers); anyone who can read the wire can read it. The desktop plugin
+  refuses `ws://` to public hosts.
 - **August 2026 macOS Screen Sharing CVE (CVE-2026-65400).** Unpatched Screen
   Sharing can authenticate an attacker on the network **without valid
   credentials**. Apple patched this in macOS **Sonoma 14.8.9**,
@@ -332,11 +342,8 @@ stream), paste the printed token, turn on HD.
   Sharing. `connect-mac.sh` warns if `sw_vers` is below those builds. Never
   publish port 5900.
 - **VNC passwords are weak.** Classic VNC authentication is DES with an
-  **8-character** secret (longer passwords are truncated). Treat it as a LAN
-  PIN, not an account password.
-- **`ws://` is unencrypted.** That is fine on a private net (this machine,
-  LAN, Tailscale). Public hosts need `wss://` with a trusted certificate;
-  self-signed certs fail *silently* at the websocket layer.
+  **8-character** secret (longer passwords are truncated). Treat it as a
+  second factor, not the boundary.
 
 Passwords stored by the plugin live in plugin storage **in plain text**
 (`hermes.plugin.computer-viewer.*`). Prefer a token in the WebSocket URL or a
@@ -466,8 +473,9 @@ VNC password.
    (`RunAtLoad` + `KeepAlive`, `ThrottleInterval` 10) whose
    `ProgramArguments` use the **absolute** venv `websockify` (launchd has a
    bare PATH - `pip --user` is not visible). Mapping is
-   `6080 -> localhost:5900`. Logs: `~/.hermes-cv/websockify.log`. It prints
-   `ws://<LocalHostName>.local:6080/websockify`. Tailscale names work too.
+   `<bind>:6080 -> localhost:5900` (Tailscale IPv4, else loopback; see
+   `CV_BIND`). Logs: `~/.hermes-cv/websockify.log`. It prints the paste
+   address for that bind (SSH tunnel recipe when loopback).
 3. In the plugin: paste that address, then **Username** (your Mac login) and
    **Password** (the Screen Sharing VNC password). Update macOS past the
    Aug-2026 Screen Sharing CVE before exposing anything (see **Security**).
@@ -495,8 +503,9 @@ installs Python 3.12 if needed (`winget ... Python.Python.3.12 --scope
 machine`), pins `websockify==0.13.0`, and registers a SYSTEM scheduled task
 at startup with `RestartCount 3` / `RestartInterval 1min` and
 **`ExecutionTimeLimit` zero** (the default would kill the task after 72
-hours). Command: `python -m websockify 0.0.0.0:6080 127.0.0.1:5900`. Firewall:
-inbound TCP 6080 on the **Private** profile only.
+hours). Command: `python -m websockify <bind>:6080 127.0.0.1:5900` (`<bind>`
+is the Tailscale IPv4, loopback, or `-Bind`). Firewall: inbound TCP 6080 on
+the **Private** profile only.
 
 It prints `ws://<COMPUTERNAME>:6080/websockify` and the generated 8-character
 VNC password. UAC prompts are visible in TightVNC service mode (expected).
@@ -545,7 +554,7 @@ Branches on `$XDG_SESSION_TYPE`:
   `~/.hermes-cv/vncpwd`, and enables systemd **user** units
   `computer-viewer-x11vnc.service` (`x11vnc -localhost -forever -shared
   -noxdamage -rfbauth ... -rfbport 5900`) and
-  `computer-viewer-websockify.service` (`6080 -> localhost:5900`,
+  `computer-viewer-websockify.service` (`<bind>:6080 -> localhost:5900`,
   `Restart=always`). `loginctl enable-linger` keeps them up without a login.
 - **wlroots Wayland** (Sway, Hyprland, ...) - `wayvnc` on localhost with
   RSA-AES / `relax_encryption`, websockify in front. Best-effort; noVNC may

--- a/computer-viewer/connect-linux.sh
+++ b/computer-viewer/connect-linux.sh
@@ -2,8 +2,9 @@
 # Bridge this Linux desktop (x11vnc on X11, wayvnc on wlroots-Wayland) to a
 # WebSocket the Computer plugin can paste: ws://<hostname>:6080/websockify
 #
-# Idempotent. VNC binds localhost:5900; only websocket :6080 is on the LAN.
-# LAN / Tailscale only. GNOME/KDE Wayland is not supported - log into Xorg.
+# Idempotent. VNC binds localhost:5900. websockify :6080 binds the Tailscale
+# IPv4 if present, else loopback. CV_BIND=0.0.0.0 for every interface (LAN only).
+# GNOME/KDE Wayland is not supported - log into Xorg.
 
 set -euo pipefail
 
@@ -27,7 +28,7 @@ WEBSOCKIFY_PIN='websockify==0.13.0'
 VENV_DIR="${HERMES_CV}/venv"
 
 echo "Computer viewer - Linux desktop bridge"
-echo "LAN / Tailscale only - VNC stays on localhost:${VNC_PORT}; websocket on :${LISTEN_PORT}."
+echo "LAN / Tailscale only - VNC stays on localhost:${VNC_PORT}; websocket bind is chosen below."
 echo
 
 umask 077
@@ -35,6 +36,39 @@ mkdir -p "${HERMES_CV}" "${UNIT_DIR}"
 
 lc() {
   printf '%s' "$1" | tr '[:upper:]' '[:lower:]'
+}
+
+resolve_bind() {
+  # Env override wins.
+  case "${CV_BIND:-}" in
+    "")        ;;
+    lan|0.0.0.0) printf '0.0.0.0'; return ;;
+    *)         printf '%s' "${CV_BIND}"; return ;;
+  esac
+  # Tailscale present and up -> bind its IPv4 only.
+  if command -v tailscale >/dev/null 2>&1; then
+    ip="$(tailscale ip -4 2>/dev/null | head -n1 | tr -d '[:space:]')"
+    case "$ip" in 100.*) printf '%s' "$ip"; return ;; esac
+  fi
+  printf '127.0.0.1'
+}
+
+announce_bind() {
+  case "$1" in
+    0.0.0.0)
+      echo "==> Bind: 0.0.0.0 (CV_BIND override) WARNING: every interface, plaintext, LAN-only use."
+      ;;
+    127.0.0.1)
+      echo "==> Bind: 127.0.0.1 (no Tailscale found; reach it through an SSH tunnel or set CV_BIND=0.0.0.0)"
+      ;;
+    *)
+      if [ -n "${CV_BIND:-}" ]; then
+        echo "==> Bind: $1 (CV_BIND override)"
+      else
+        echo "==> Bind: $1 (Tailscale interface; set CV_BIND=0.0.0.0 for every interface)"
+      fi
+      ;;
+  esac
 }
 
 port_listening() {
@@ -166,7 +200,7 @@ After=network.target
 
 [Service]
 Type=simple
-ExecStart=${ws_bin} ${LISTEN_PORT} localhost:${VNC_PORT}
+ExecStart=${ws_bin} ${BIND}:${LISTEN_PORT} localhost:${VNC_PORT}
 Restart=always
 RestartSec=3
 
@@ -261,17 +295,48 @@ guess_wayland_family() {
 }
 
 print_paste() {
-  local host pw
+  local host pw ts_dns=""
   host="$(hostname -s 2>/dev/null || hostname)"
   pw="${1:-}"
+  if command -v tailscale >/dev/null 2>&1 && command -v python3 >/dev/null 2>&1; then
+    ts_dns="$(tailscale status --json 2>/dev/null | python3 -c 'import sys,json
+try:
+    d=json.load(sys.stdin)
+    n=(d.get("Self") or {}).get("DNSName") or ""
+    print(n.rstrip("."))
+except Exception:
+    print("")
+' || true)"
+  fi
   echo
   echo "===================================================================="
   echo "Paste this address in Computer:"
-  echo "  ws://${host}:${LISTEN_PORT}/websockify"
-  echo
-  echo "mDNS:        ws://${host}.local:${LISTEN_PORT}/websockify"
-  echo "Tailscale:   ws://<tailscale-name>:${LISTEN_PORT}/websockify"
-  echo "(.local and Tailscale MagicDNS both work on a private net.)"
+  case "$BIND" in
+    127.0.0.1)
+      echo "  Reach it through an SSH tunnel:"
+      echo "    ssh -N -L ${LISTEN_PORT}:127.0.0.1:${LISTEN_PORT} ${USER}@${host}"
+      echo "  then paste:"
+      echo "    ws://127.0.0.1:${LISTEN_PORT}/websockify"
+      ;;
+    0.0.0.0)
+      echo "  ws://${host}:${LISTEN_PORT}/websockify"
+      echo
+      echo "mDNS:        ws://${host}.local:${LISTEN_PORT}/websockify"
+      echo "Tailscale:   ws://<tailscale-name>:${LISTEN_PORT}/websockify"
+      echo "(.local and Tailscale MagicDNS both work on a private net.)"
+      echo
+      echo "WARNING: bound to every interface, plaintext. LAN-only use."
+      ;;
+    *)
+      echo "  ws://${BIND}:${LISTEN_PORT}/websockify"
+      if [ -n "$ts_dns" ]; then
+        echo "  ws://${ts_dns}:${LISTEN_PORT}/websockify"
+      else
+        echo "  ws://<tailscale-name>:${LISTEN_PORT}/websockify"
+      fi
+      echo "(.local and Tailscale MagicDNS both work on a private net.)"
+      ;;
+  esac
   echo
   if [ -n "$pw" ]; then
     echo "Linux VNC password (paste into the plugin Password field):"
@@ -282,7 +347,7 @@ print_paste() {
   fi
   echo
   echo "LAN / Tailscale only. Do not port-forward ${VNC_PORT} or ${LISTEN_PORT}."
-  echo "VNC is bound to localhost; only the websocket port is reachable."
+  echo "VNC stays on localhost:${VNC_PORT}. websockify is bound to ${BIND}:${LISTEN_PORT}."
   echo "===================================================================="
 }
 
@@ -443,6 +508,9 @@ refuse_gnome_kde_wayland() {
 }
 
 # --- main -------------------------------------------------------------------
+
+BIND="$(resolve_bind)"
+announce_bind "$BIND"
 
 SESSION="$(detect_session)"
 echo "==> XDG_SESSION_TYPE=${XDG_SESSION_TYPE:-<unset>}  DISPLAY=${DISPLAY:-<unset>}  WAYLAND_DISPLAY=${WAYLAND_DISPLAY:-<unset>}"

--- a/computer-viewer/connect-mac.sh
+++ b/computer-viewer/connect-mac.sh
@@ -32,11 +32,44 @@ TAHOE_PATCHED='26.6.1'
 
 echo "Computer viewer - Mac Screen Sharing bridge"
 echo "websockify ${WEBSOCKIFY_PIN}, pinned in ${VENV_DIR}"
-echo "LAN / Tailscale only - VNC stays on localhost:5900; websocket on :${LISTEN_PORT}."
+echo "LAN / Tailscale only - VNC stays on localhost:5900; websocket bind is chosen below."
 echo
 
 xml_escape() {
   printf '%s' "$1" | sed -e 's/\&/\&amp;/g' -e 's/</\&lt;/g' -e 's/>/\&gt;/g'
+}
+
+resolve_bind() {
+  # Env override wins.
+  case "${CV_BIND:-}" in
+    "")        ;;
+    lan|0.0.0.0) printf '0.0.0.0'; return ;;
+    *)         printf '%s' "${CV_BIND}"; return ;;
+  esac
+  # Tailscale present and up -> bind its IPv4 only.
+  if command -v tailscale >/dev/null 2>&1; then
+    ip="$(tailscale ip -4 2>/dev/null | head -n1 | tr -d '[:space:]')"
+    case "$ip" in 100.*) printf '%s' "$ip"; return ;; esac
+  fi
+  printf '127.0.0.1'
+}
+
+announce_bind() {
+  case "$1" in
+    0.0.0.0)
+      echo "==> Bind: 0.0.0.0 (CV_BIND override) WARNING: every interface, plaintext, LAN-only use."
+      ;;
+    127.0.0.1)
+      echo "==> Bind: 127.0.0.1 (no Tailscale found; reach it through an SSH tunnel or set CV_BIND=0.0.0.0)"
+      ;;
+    *)
+      if [ -n "${CV_BIND:-}" ]; then
+        echo "==> Bind: $1 (CV_BIND override)"
+      else
+        echo "==> Bind: $1 (Tailscale interface; set CV_BIND=0.0.0.0 for every interface)"
+      fi
+      ;;
+  esac
 }
 
 # Return 0 if dotted version $1 >= $2. Best-effort numeric; bash 3.2 safe.
@@ -150,6 +183,12 @@ detect_hostname() {
 
 warn_screen_sharing_cve
 
+if ! command -v tailscale >/dev/null 2>&1 && [ -x /Applications/Tailscale.app/Contents/MacOS/Tailscale ]; then
+  PATH="/Applications/Tailscale.app/Contents/MacOS:${PATH}"
+fi
+BIND="$(resolve_bind)"
+announce_bind "$BIND"
+
 if ! command -v python3 >/dev/null 2>&1; then
   echo "python3 not found. Install Python 3 (Xcode Command Line Tools or python.org) and re-run." >&2
   echo "  xcode-select --install" >&2
@@ -187,6 +226,7 @@ echo "    ${WEBSOCKIFY_BIN}"
 BIN_XML="$(xml_escape "${WEBSOCKIFY_BIN}")"
 LOG_XML="$(xml_escape "${LOG_PATH}")"
 LABEL_XML="$(xml_escape "${LABEL}")"
+BIND_PORT_XML="$(xml_escape "${BIND}:${LISTEN_PORT}")"
 
 echo "==> Writing LaunchAgent ${PLIST}"
 cat > "${PLIST}" <<EOF
@@ -199,7 +239,7 @@ cat > "${PLIST}" <<EOF
   <key>ProgramArguments</key>
   <array>
     <string>${BIN_XML}</string>
-    <string>${LISTEN_PORT}</string>
+    <string>${BIND_PORT_XML}</string>
     <string>${VNC_TARGET}</string>
   </array>
   <key>RunAtLoad</key>
@@ -234,7 +274,7 @@ if command -v launchctl >/dev/null 2>&1; then
   launchctl enable "${DOMAIN}/${LABEL}" >/dev/null 2>&1 || true
   launchctl kickstart -k "${DOMAIN}/${LABEL}" >/dev/null 2>&1 || \
     launchctl start "${LABEL}" >/dev/null 2>&1 || true
-  echo "    Loaded ${LABEL} (websockify ${LISTEN_PORT} -> ${VNC_TARGET}, RunAtLoad + KeepAlive)."
+  echo "    Loaded ${LABEL} (websockify ${BIND}:${LISTEN_PORT} -> ${VNC_TARGET}, RunAtLoad + KeepAlive)."
 else
   echo "launchctl not found; plist is in place but was not loaded." >&2
 fi
@@ -267,20 +307,52 @@ fi
 
 HOST="$(detect_hostname)"
 MAC_USER="$(whoami)"
+TS_DNS=""
+if command -v tailscale >/dev/null 2>&1 && command -v python3 >/dev/null 2>&1; then
+  TS_DNS="$(tailscale status --json 2>/dev/null | python3 -c 'import sys,json
+try:
+    d=json.load(sys.stdin)
+    n=(d.get("Self") or {}).get("DNSName") or ""
+    print(n.rstrip("."))
+except Exception:
+    print("")
+' || true)"
+fi
 
 echo
 echo "===================================================================="
 echo "Paste this address in Computer:"
-echo "  ws://${HOST}:${LISTEN_PORT}/websockify"
+case "$BIND" in
+  127.0.0.1)
+    echo "  Reach it through an SSH tunnel:"
+    echo "    ssh -N -L ${LISTEN_PORT}:127.0.0.1:${LISTEN_PORT} ${MAC_USER}@${HOST}"
+    echo "  then paste:"
+    echo "    ws://127.0.0.1:${LISTEN_PORT}/websockify"
+    ;;
+  0.0.0.0)
+    echo "  ws://${HOST}:${LISTEN_PORT}/websockify"
+    echo
+    echo "Tailscale names work too (ws://<tailscale-name>:${LISTEN_PORT}/websockify)."
+    echo ".local (Bonjour) and Tailscale MagicDNS both resolve on a private net."
+    echo
+    echo "WARNING: bound to every interface, plaintext. LAN-only use."
+    ;;
+  *)
+    echo "  ws://${BIND}:${LISTEN_PORT}/websockify"
+    if [ -n "${TS_DNS}" ]; then
+      echo "  ws://${TS_DNS}:${LISTEN_PORT}/websockify"
+    else
+      echo "  ws://<tailscale-name>:${LISTEN_PORT}/websockify"
+    fi
+    echo ".local (Bonjour) and Tailscale MagicDNS both resolve on a private net."
+    ;;
+esac
 echo
 echo "The plugin also needs:"
 echo "  Username  ${MAC_USER}   (your Mac login, Advanced -> Username)"
 echo "  Password  the 8-char VNC password you set in Screen Sharing"
 echo
-echo "Tailscale names work too (ws://<tailscale-name>:${LISTEN_PORT}/websockify)."
-echo ".local (Bonjour) and Tailscale MagicDNS both resolve on a private net."
-echo
 echo "LAN / Tailscale only. Do not port-forward 5900 or ${LISTEN_PORT}."
-echo "VNC is bound to localhost; only the websocket port is reachable."
+echo "VNC stays on localhost:5900. websockify is bound to ${BIND}:${LISTEN_PORT}."
 echo "Logs: ${LOG_PATH}"
 echo "===================================================================="

--- a/computer-viewer/connect-windows.ps1
+++ b/computer-viewer/connect-windows.ps1
@@ -21,6 +21,10 @@
   print the HDMI dummy-plug fallback. Machines with a real monitor are unchanged.
 #>
 
+param(
+    [string]$Bind = ''
+)
+
 $ErrorActionPreference = 'Stop'
 $ListenPort = 6080
 $VncPort = 5900
@@ -61,11 +65,13 @@ if (-not (Test-IsAdmin)) {
         Set-Content -LiteralPath $file -Value $text -Encoding UTF8
     }
     try {
-        $proc = Start-Process -FilePath 'powershell.exe' -Verb RunAs -PassThru -Wait -ArgumentList @(
+        $argList = @(
             '-NoProfile',
             '-ExecutionPolicy', 'Bypass',
             '-File', $file
         )
+        if ($Bind) { $argList += @('-Bind', $Bind) }
+        $proc = Start-Process -FilePath 'powershell.exe' -Verb RunAs -PassThru -Wait -ArgumentList $argList
         if ($null -ne $proc) { exit $proc.ExitCode }
         exit 0
     } catch {
@@ -74,8 +80,27 @@ if (-not (Test-IsAdmin)) {
     }
 }
 
+if (-not $Bind) {
+    try {
+        $tsIp = (tailscale ip -4 2>$null | Select-Object -First 1)
+        if ($tsIp) { $tsIp = ([string]$tsIp).Trim() }
+        if ($tsIp -match '^100\.') { $Bind = $tsIp }
+    } catch {}
+}
+if (-not $Bind) { $Bind = '127.0.0.1' }
+
+if ($Bind -eq '0.0.0.0') {
+    Write-Host "==> Bind: 0.0.0.0 (-Bind override) WARNING: every interface, plaintext, LAN-only use."
+} elseif ($Bind -eq '127.0.0.1') {
+    Write-Host "==> Bind: 127.0.0.1 (no Tailscale found; reach it through an SSH tunnel or set -Bind 0.0.0.0)"
+} elseif ($Bind -match '^100\.') {
+    Write-Host "==> Bind: $Bind (Tailscale interface; set -Bind 0.0.0.0 for every interface)"
+} else {
+    Write-Host "==> Bind: $Bind (-Bind override)"
+}
+
 Write-Host 'Computer viewer - Windows TightVNC + websockify bridge'
-Write-Host "LAN / Tailscale only - VNC stays on 127.0.0.1:$VncPort; websocket on 0.0.0.0:$ListenPort."
+Write-Host "LAN / Tailscale only - VNC stays on 127.0.0.1:$VncPort; websocket on ${Bind}:$ListenPort."
 Write-Host ''
 
 function New-VncPassword8 {
@@ -605,7 +630,7 @@ if ($LASTEXITCODE -ne 0) {
 
 Write-Step "Registering scheduled task $TaskName (SYSTEM, AtStartup, ExecutionTimeLimit=0)"
 # Default ExecutionTimeLimit is 72 hours - the task would be killed. Zero = unlimited.
-$action = New-ScheduledTaskAction -Execute $python -Argument "-m websockify 0.0.0.0:$ListenPort 127.0.0.1:$VncPort"
+$action = New-ScheduledTaskAction -Execute $python -Argument "-m websockify ${Bind}:$ListenPort 127.0.0.1:$VncPort"
 $trigger = New-ScheduledTaskTrigger -AtStartup
 $principal = New-ScheduledTaskPrincipal -UserId 'SYSTEM' -LogonType ServiceAccount -RunLevel Highest
 $settings = New-ScheduledTaskSettingsSet `
@@ -687,7 +712,21 @@ if (-not $hostname) {
 Write-Host ''
 Write-Host '===================================================================='
 Write-Host 'Paste this address in Computer:'
-Write-Host "  ws://${hostname}:${ListenPort}/websockify"
+if ($Bind -eq '127.0.0.1') {
+    Write-Host '  Reach it through an SSH tunnel:'
+    Write-Host ("    ssh -N -L {0}:127.0.0.1:{0} {1}@{2}" -f $ListenPort, $env:USERNAME, $hostname)
+    Write-Host '  then paste:'
+    Write-Host "    ws://127.0.0.1:${ListenPort}/websockify"
+} elseif ($Bind -eq '0.0.0.0') {
+    Write-Host "  ws://${hostname}:${ListenPort}/websockify"
+    Write-Host '  Tailscale names work too: ws://<tailscale-name>:6080/websockify'
+    Write-Host '  .local / MagicDNS both work on a private net.'
+    Write-Host '  WARNING: bound to every interface, plaintext. LAN-only use.'
+} else {
+    Write-Host "  ws://${Bind}:${ListenPort}/websockify"
+    Write-Host '  Tailscale names work too: ws://<tailscale-name>:6080/websockify'
+    Write-Host '  .local / MagicDNS both work on a private net.'
+}
 Write-Host ''
 Write-Host 'VNC password (paste into the plugin Password field):'
 Write-Host "  $vncPassword"
@@ -696,11 +735,9 @@ Write-Host ''
 Write-Host 'Notes:'
 Write-Host '  - Run in Administrator PowerShell (this script self-elevates).'
 Write-Host '  - LAN / Tailscale only. Do not port-forward 5900 or 6080.'
-Write-Host '  - TightVNC is loopback-only; only the websocket port is on the LAN.'
+Write-Host "  - TightVNC is loopback-only. websockify is bound to ${Bind}:$ListenPort."
 Write-Host '  - UAC prompts show only in TightVNC service mode - they will. That is expected.'
 Write-Host '  - Defender may flag VNC. Allow TightVNC / tvnserver if it quarantines it.'
-Write-Host '  - Tailscale names work too: ws://<tailscale-name>:6080/websockify'
-Write-Host '  - .local / MagicDNS both work on a private net.'
 if ($headless) {
     Write-Host '  - Headless: Amyuni usbmmidd virtual display (default 1920x1080).'
     Write-Host '    enableidd is re-applied at boot by task ComputerViewerVirtualDisplay.'

--- a/computer-viewer/hiperf-agent.py
+++ b/computer-viewer/hiperf-agent.py
@@ -1187,7 +1187,7 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument('--fps', type=int, default=30)
     p.add_argument('--bitrate', default='8M')
     p.add_argument('--display', default=':0')
-    p.add_argument('--bind', default='0.0.0.0')
+    p.add_argument('--bind', default='127.0.0.1')
     return p
 
 

--- a/computer-viewer/hiperf-linux.sh
+++ b/computer-viewer/hiperf-linux.sh
@@ -24,11 +24,44 @@ RAW_REPO_URL='https://raw.githubusercontent.com/thomasbek3/hermes-bot-kit/master
 WEBSOCKETS_PIN='websockets>=13,<16'
 
 echo "Computer viewer - high-performance stream (Linux)"
-echo "LAN / Tailscale only - H.264 agent on :${LISTEN_PORT}."
+echo "LAN / Tailscale only - H.264 agent bind is chosen below (port ${LISTEN_PORT})."
 echo
 
 umask 077
 mkdir -p "${HIPERF_DIR}" "${HERMES_CV}" "${UNIT_DIR}"
+
+resolve_bind() {
+  # Env override wins.
+  case "${CV_BIND:-}" in
+    "")        ;;
+    lan|0.0.0.0) printf '0.0.0.0'; return ;;
+    *)         printf '%s' "${CV_BIND}"; return ;;
+  esac
+  # Tailscale present and up -> bind its IPv4 only.
+  if command -v tailscale >/dev/null 2>&1; then
+    ip="$(tailscale ip -4 2>/dev/null | head -n1 | tr -d '[:space:]')"
+    case "$ip" in 100.*) printf '%s' "$ip"; return ;; esac
+  fi
+  printf '127.0.0.1'
+}
+
+announce_bind() {
+  case "$1" in
+    0.0.0.0)
+      echo "==> Bind: 0.0.0.0 (CV_BIND override) WARNING: every interface, plaintext, LAN-only use."
+      ;;
+    127.0.0.1)
+      echo "==> Bind: 127.0.0.1 (no Tailscale found; reach it through an SSH tunnel or set CV_BIND=0.0.0.0)"
+      ;;
+    *)
+      if [ -n "${CV_BIND:-}" ]; then
+        echo "==> Bind: $1 (CV_BIND override)"
+      else
+        echo "==> Bind: $1 (Tailscale interface; set CV_BIND=0.0.0.0 for every interface)"
+      fi
+      ;;
+  esac
+}
 
 port_listening() {
   local port="$1"
@@ -221,6 +254,9 @@ PYTHON_BIN="${VENV_DIR}/bin/python"
 DISPLAY_VAL="${DISPLAY:-:0}"
 XAUTH_VAL="${XAUTHORITY:-%h/.Xauthority}"
 
+BIND="$(resolve_bind)"
+announce_bind "$BIND"
+
 echo "==> Writing systemd user unit ${UNIT_FILE}"
 cat > "${UNIT_FILE}" <<EOF
 [Unit]
@@ -231,7 +267,7 @@ After=graphical-session.target
 Type=simple
 Environment=DISPLAY=${DISPLAY_VAL}
 Environment=XAUTHORITY=${XAUTH_VAL}
-ExecStart=${PYTHON_BIN} ${AGENT_PATH} --port ${LISTEN_PORT} --token-file ${TOKEN_FILE} --ffmpeg ${FFMPEG_BIN} --bind 0.0.0.0 --display ${DISPLAY_VAL}
+ExecStart=${PYTHON_BIN} ${AGENT_PATH} --port ${LISTEN_PORT} --token-file ${TOKEN_FILE} --ffmpeg ${FFMPEG_BIN} --bind ${BIND} --display ${DISPLAY_VAL}
 Restart=on-failure
 RestartSec=10
 
@@ -250,10 +286,8 @@ else
 fi
 
 HOST="$(hostname -s 2>/dev/null || hostname)"
-TS_IP=""
 TS_DNS=""
 if command -v tailscale >/dev/null 2>&1; then
-  TS_IP="$(tailscale ip -4 2>/dev/null | head -n 1 || true)"
   TS_DNS="$(tailscale status --json 2>/dev/null | python3 -c 'import sys,json
 try:
     d=json.load(sys.stdin)
@@ -276,15 +310,33 @@ echo "  ${TOKEN}"
 echo "  stored at ${TOKEN_FILE} (mode 600)"
 echo
 echo "Optional stream URL override (leave blank to derive :6090 from the VNC host):"
-echo "  ws://${HOST}:${LISTEN_PORT}/stream"
-echo "  ws://${HOST}.local:${LISTEN_PORT}/stream"
-if [ -n "${TS_DNS}" ]; then
-  echo "  ws://${TS_DNS}:${LISTEN_PORT}/stream"
-fi
-if [ -n "${TS_IP}" ]; then
-  echo "  ws://${TS_IP}:${LISTEN_PORT}/stream"
-fi
+case "$BIND" in
+  127.0.0.1)
+    echo "  Reach it through an SSH tunnel:"
+    echo "    ssh -N -L ${LISTEN_PORT}:127.0.0.1:${LISTEN_PORT} ${USER}@${HOST}"
+    echo "  then paste:"
+    echo "    ws://127.0.0.1:${LISTEN_PORT}/stream"
+    ;;
+  0.0.0.0)
+    echo "  ws://${HOST}:${LISTEN_PORT}/stream"
+    echo "  ws://${HOST}.local:${LISTEN_PORT}/stream"
+    if [ -n "${TS_DNS}" ]; then
+      echo "  ws://${TS_DNS}:${LISTEN_PORT}/stream"
+    fi
+    echo "  WARNING: bound to every interface, plaintext. LAN-only use."
+    ;;
+  *)
+    echo "  ws://${BIND}:${LISTEN_PORT}/stream"
+    if [ -n "${TS_DNS}" ]; then
+      echo "  ws://${TS_DNS}:${LISTEN_PORT}/stream"
+    else
+      echo "  ws://<tailscale-name>:${LISTEN_PORT}/stream"
+    fi
+    echo "(.local and Tailscale MagicDNS both work on a private net.)"
+    ;;
+esac
 echo
 echo "LAN / Tailscale only. Do not port-forward ${LISTEN_PORT}."
+echo "HD agent is bound to ${BIND}:${LISTEN_PORT}."
 echo "X11 only. On Wayland the agent stays up but capture fails (use an Xorg session)."
 echo "===================================================================="

--- a/computer-viewer/hiperf-mac.sh
+++ b/computer-viewer/hiperf-mac.sh
@@ -28,11 +28,44 @@ RAW_REPO_URL='https://raw.githubusercontent.com/thomasbek3/hermes-bot-kit/master
 WEBSOCKETS_PIN='websockets>=13,<16'
 
 echo "Computer viewer - high-performance stream (macOS)"
-echo "LAN / Tailscale only - H.264 agent on :${LISTEN_PORT}."
+echo "LAN / Tailscale only - H.264 agent bind is chosen below (port ${LISTEN_PORT})."
 echo
 
 xml_escape() {
   printf '%s' "$1" | sed -e 's/\&/\&amp;/g' -e 's/</\&lt;/g' -e 's/>/\&gt;/g'
+}
+
+resolve_bind() {
+  # Env override wins.
+  case "${CV_BIND:-}" in
+    "")        ;;
+    lan|0.0.0.0) printf '0.0.0.0'; return ;;
+    *)         printf '%s' "${CV_BIND}"; return ;;
+  esac
+  # Tailscale present and up -> bind its IPv4 only.
+  if command -v tailscale >/dev/null 2>&1; then
+    ip="$(tailscale ip -4 2>/dev/null | head -n1 | tr -d '[:space:]')"
+    case "$ip" in 100.*) printf '%s' "$ip"; return ;; esac
+  fi
+  printf '127.0.0.1'
+}
+
+announce_bind() {
+  case "$1" in
+    0.0.0.0)
+      echo "==> Bind: 0.0.0.0 (CV_BIND override) WARNING: every interface, plaintext, LAN-only use."
+      ;;
+    127.0.0.1)
+      echo "==> Bind: 127.0.0.1 (no Tailscale found; reach it through an SSH tunnel or set CV_BIND=0.0.0.0)"
+      ;;
+    *)
+      if [ -n "${CV_BIND:-}" ]; then
+        echo "==> Bind: $1 (CV_BIND override)"
+      else
+        echo "==> Bind: $1 (Tailscale interface; set CV_BIND=0.0.0.0 for every interface)"
+      fi
+      ;;
+  esac
 }
 
 port_listening() {
@@ -206,6 +239,12 @@ if [ -z "${BREW_PREFIX}" ]; then
 fi
 PATH_VALUE="${HERMES_CV}/bin:${BREW_PREFIX:+${BREW_PREFIX}/bin:}/usr/local/bin:/usr/bin:/bin"
 
+if ! command -v tailscale >/dev/null 2>&1 && [ -x /Applications/Tailscale.app/Contents/MacOS/Tailscale ]; then
+  PATH="/Applications/Tailscale.app/Contents/MacOS:${PATH}"
+fi
+BIND="$(resolve_bind)"
+announce_bind "$BIND"
+
 echo "==> Capture probe (will not obtain Screen Recording permission by itself)"
 echo "    A launchd-started agent cannot show the TCC prompt, and launchctl asuser"
 echo "    requires root, so this script cannot grant Screen Recording for you."
@@ -215,7 +254,7 @@ set +e
   --port "${LISTEN_PORT}" \
   --token-file "${TOKEN_FILE}" \
   --ffmpeg "${FFMPEG_BIN}" \
-  --bind 127.0.0.1 &
+  --bind "${BIND}" &
 PROBE_PID=$!
 sleep 8
 kill "${PROBE_PID}" >/dev/null 2>&1
@@ -232,6 +271,7 @@ LABEL_XML="$(xml_escape "${LABEL}")"
 PATH_XML="$(xml_escape "${PATH_VALUE}")"
 WD_XML="$(xml_escape "${HIPERF_DIR}")"
 PORT_XML="$(xml_escape "${LISTEN_PORT}")"
+BIND_XML="$(xml_escape "${BIND}")"
 
 echo "==> Writing LaunchAgent ${PLIST}"
 cat > "${PLIST}" <<EOF
@@ -252,7 +292,7 @@ cat > "${PLIST}" <<EOF
     <string>--ffmpeg</string>
     <string>${FFMPEG_XML}</string>
     <string>--bind</string>
-    <string>0.0.0.0</string>
+    <string>${BIND_XML}</string>
   </array>
   <key>RunAtLoad</key>
   <true/>
@@ -304,10 +344,9 @@ else
 fi
 
 HOST="$(detect_hostname)"
-TS_IP=""
+MAC_USER="$(whoami)"
 TS_DNS=""
 if command -v tailscale >/dev/null 2>&1; then
-  TS_IP="$(tailscale ip -4 2>/dev/null | head -n 1 || true)"
   TS_DNS="$(tailscale status --json 2>/dev/null | "${PYTHON_CMD}" -c 'import sys,json
 try:
     d=json.load(sys.stdin)
@@ -330,15 +369,33 @@ echo "  ${TOKEN}"
 echo "  stored at ${TOKEN_FILE} (mode 600)"
 echo
 echo "Optional stream URL override (leave blank to derive :6090 from the VNC host):"
-echo "  ws://${HOST}:${LISTEN_PORT}/stream"
-if [ -n "${TS_DNS}" ]; then
-  echo "  ws://${TS_DNS}:${LISTEN_PORT}/stream"
-fi
-if [ -n "${TS_IP}" ]; then
-  echo "  ws://${TS_IP}:${LISTEN_PORT}/stream"
-fi
+case "$BIND" in
+  127.0.0.1)
+    echo "  Reach it through an SSH tunnel:"
+    echo "    ssh -N -L ${LISTEN_PORT}:127.0.0.1:${LISTEN_PORT} ${MAC_USER}@${HOST}"
+    echo "  then paste:"
+    echo "    ws://127.0.0.1:${LISTEN_PORT}/stream"
+    ;;
+  0.0.0.0)
+    echo "  ws://${HOST}:${LISTEN_PORT}/stream"
+    if [ -n "${TS_DNS}" ]; then
+      echo "  ws://${TS_DNS}:${LISTEN_PORT}/stream"
+    fi
+    echo "  WARNING: bound to every interface, plaintext. LAN-only use."
+    ;;
+  *)
+    echo "  ws://${BIND}:${LISTEN_PORT}/stream"
+    if [ -n "${TS_DNS}" ]; then
+      echo "  ws://${TS_DNS}:${LISTEN_PORT}/stream"
+    else
+      echo "  ws://<tailscale-name>:${LISTEN_PORT}/stream"
+    fi
+    echo ".local (Bonjour) and Tailscale MagicDNS both resolve on a private net."
+    ;;
+esac
 echo
 echo "LAN / Tailscale only. Do not port-forward ${LISTEN_PORT}."
+echo "HD agent is bound to ${BIND}:${LISTEN_PORT}."
 echo
 echo "The Mac must be LOGGED IN (not at the lock screen) or capture shows only"
 echo "the lock screen."

--- a/computer-viewer/hiperf-windows.ps1
+++ b/computer-viewer/hiperf-windows.ps1
@@ -13,6 +13,10 @@
   Desktop capture (ddagrab / gdigrab) needs the interactive user session.
 #>
 
+param(
+    [string]$Bind = ''
+)
+
 $ErrorActionPreference = 'Stop'
 $ListenPort = 6090
 $TaskName = 'ComputerViewerHiperf'
@@ -51,11 +55,13 @@ if (-not (Test-IsAdmin)) {
         Set-Content -LiteralPath $file -Value $text -Encoding UTF8
     }
     try {
-        $proc = Start-Process -FilePath 'powershell.exe' -Verb RunAs -PassThru -Wait -ArgumentList @(
+        $argList = @(
             '-NoProfile',
             '-ExecutionPolicy', 'Bypass',
             '-File', $file
         )
+        if ($Bind) { $argList += @('-Bind', $Bind) }
+        $proc = Start-Process -FilePath 'powershell.exe' -Verb RunAs -PassThru -Wait -ArgumentList $argList
         if ($null -ne $proc) { exit $proc.ExitCode }
         exit 0
     } catch {
@@ -71,8 +77,27 @@ if (-not $InstallUser) {
     else { $InstallUser = $env:USERNAME }
 }
 
+if (-not $Bind) {
+    try {
+        $tsIp = (tailscale ip -4 2>$null | Select-Object -First 1)
+        if ($tsIp) { $tsIp = ([string]$tsIp).Trim() }
+        if ($tsIp -match '^100\.') { $Bind = $tsIp }
+    } catch {}
+}
+if (-not $Bind) { $Bind = '127.0.0.1' }
+
+if ($Bind -eq '0.0.0.0') {
+    Write-Host "==> Bind: 0.0.0.0 (-Bind override) WARNING: every interface, plaintext, LAN-only use."
+} elseif ($Bind -eq '127.0.0.1') {
+    Write-Host "==> Bind: 127.0.0.1 (no Tailscale found; reach it through an SSH tunnel or set -Bind 0.0.0.0)"
+} elseif ($Bind -match '^100\.') {
+    Write-Host "==> Bind: $Bind (Tailscale interface; set -Bind 0.0.0.0 for every interface)"
+} else {
+    Write-Host "==> Bind: $Bind (-Bind override)"
+}
+
 Write-Host 'Computer viewer - high-performance stream (Windows)'
-Write-Host "LAN / Tailscale only - H.264 agent on 0.0.0.0:$ListenPort as $InstallUser."
+Write-Host "LAN / Tailscale only - H.264 agent on ${Bind}:$ListenPort as $InstallUser."
 Write-Host ''
 
 function Refresh-ProcessPath {
@@ -277,7 +302,7 @@ if (-not (Test-Path -LiteralPath $venvPythonw)) {
 Write-Step "Registering scheduled task $TaskName (user=$InstallUser, LogonType=Interactive, AtLogOn, ExecutionTimeLimit=0)"
 # Default ExecutionTimeLimit is 72 hours - the task would be killed. Zero = unlimited.
 # SYSTEM cannot capture the interactive desktop; this task MUST run as the installing user.
-$arg = '"{0}" --port {1} --token-file "{2}" --ffmpeg "{3}" --bind 0.0.0.0' -f $AgentPath, $ListenPort, $TokenFile, $ffmpeg
+$arg = '"{0}" --port {1} --token-file "{2}" --ffmpeg "{3}" --bind {4}' -f $AgentPath, $ListenPort, $TokenFile, $ffmpeg, $Bind
 $action = New-ScheduledTaskAction -Execute $venvPythonw -Argument $arg
 $trigger = New-ScheduledTaskTrigger -AtLogOn -User $InstallUser
 $principal = New-ScheduledTaskPrincipal -UserId $InstallUser -LogonType Interactive
@@ -352,16 +377,32 @@ Write-Host "  $token"
 Write-Host "  stored at $TokenFile"
 Write-Host ''
 Write-Host 'Optional stream URL override (leave blank to derive :6090 from the VNC host):'
-Write-Host "  ws://${hostname}:${ListenPort}/stream"
-if ($tsDns) {
-    Write-Host "  ws://${tsDns}:${ListenPort}/stream"
-}
-if ($tsIp) {
-    Write-Host "  ws://${tsIp}:${ListenPort}/stream"
+if ($Bind -eq '127.0.0.1') {
+    Write-Host '  Reach it through an SSH tunnel:'
+    Write-Host ("    ssh -N -L {0}:127.0.0.1:{0} {1}@{2}" -f $ListenPort, $env:USERNAME, $hostname)
+    Write-Host '  then paste:'
+    Write-Host "    ws://127.0.0.1:${ListenPort}/stream"
+} elseif ($Bind -eq '0.0.0.0') {
+    Write-Host "  ws://${hostname}:${ListenPort}/stream"
+    if ($tsDns) {
+        Write-Host "  ws://${tsDns}:${ListenPort}/stream"
+    }
+    if ($tsIp) {
+        Write-Host "  ws://${tsIp}:${ListenPort}/stream"
+    }
+    Write-Host '  WARNING: bound to every interface, plaintext. LAN-only use.'
+} else {
+    Write-Host "  ws://${Bind}:${ListenPort}/stream"
+    if ($tsDns) {
+        Write-Host "  ws://${tsDns}:${ListenPort}/stream"
+    } else {
+        Write-Host "  ws://<tailscale-name>:${ListenPort}/stream"
+    }
 }
 Write-Host ''
 Write-Host 'Notes:'
 Write-Host '  - Run in Administrator PowerShell (this script self-elevates).'
+Write-Host "  - HD agent is bound to ${Bind}:$ListenPort."
 Write-Host '  - LAN / Tailscale only. Do not port-forward 6090.'
 Write-Host '  - Task ComputerViewerHiperf runs as the interactive user, not SYSTEM.'
 Write-Host "  - pythonw is silent; logs: $LogFile"

--- a/computer-viewer/tests/test-bind.sh
+++ b/computer-viewer/tests/test-bind.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# Extract resolve_bind from each host script and assert bind policy.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+cd "$ROOT"
+
+SCRIPTS=(
+  computer-viewer/connect-linux.sh
+  computer-viewer/connect-mac.sh
+  computer-viewer/hiperf-mac.sh
+  computer-viewer/hiperf-linux.sh
+)
+
+ENV_BIN="$(command -v env)"
+BASH_BIN="$(command -v bash)"
+fail=0
+
+run_bind() {
+  local extract="$1"
+  local inner_path="$2"
+  if [ "${3+x}" = x ]; then
+    "$ENV_BIN" -i PATH="$inner_path" HOME="${HOME:-/tmp}" CV_BIND="$3" \
+      "$BASH_BIN" --noprofile --norc -c 'set -euo pipefail; . "$1"; resolve_bind' _ "$extract"
+  else
+    "$ENV_BIN" -i PATH="$inner_path" HOME="${HOME:-/tmp}" \
+      "$BASH_BIN" --noprofile --norc -c 'set -euo pipefail; . "$1"; resolve_bind' _ "$extract"
+  fi
+}
+
+assert_eq() {
+  local script="$1" label="$2" got="$3" want="$4"
+  if [ "$got" = "$want" ]; then
+    echo "OK  ${script}  ${label} -> ${got}"
+  else
+    echo "FAIL ${script}  ${label} -> got '${got}' want '${want}'"
+    fail=1
+  fi
+}
+
+empty_dir="$(mktemp -d)"
+shim_ok="$(mktemp -d)"
+shim_empty="$(mktemp -d)"
+cleanup() {
+  rm -rf "$empty_dir" "$shim_ok" "$shim_empty"
+}
+trap cleanup EXIT
+
+cat > "${shim_ok}/tailscale" <<'EOF'
+#!/usr/bin/env bash
+if [ "${1:-}" = ip ] && [ "${2:-}" = -4 ]; then
+  printf '100.64.0.9\n'
+fi
+EOF
+chmod +x "${shim_ok}/tailscale"
+
+cat > "${shim_empty}/tailscale" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+chmod +x "${shim_empty}/tailscale"
+
+for script in "${SCRIPTS[@]}"; do
+  extract="$(mktemp)"
+  sed -n '/^resolve_bind()/,/^}/p' "$script" > "$extract"
+  if ! grep -q '^resolve_bind()' "$extract"; then
+    echo "FAIL ${script}  resolve_bind not found"
+    fail=1
+    rm -f "$extract"
+    continue
+  fi
+  if [ "$(tail -n1 "$extract")" != '}' ]; then
+    echo "FAIL ${script}  resolve_bind extract did not end at closing brace"
+    fail=1
+    rm -f "$extract"
+    continue
+  fi
+
+  got="$(run_bind "$extract" "$empty_dir" '0.0.0.0')"
+  assert_eq "$script" 'CV_BIND=0.0.0.0' "$got" '0.0.0.0'
+
+  got="$(run_bind "$extract" "$empty_dir" 'lan')"
+  assert_eq "$script" 'CV_BIND=lan' "$got" '0.0.0.0'
+
+  got="$(run_bind "$extract" "$empty_dir" '10.0.0.5')"
+  assert_eq "$script" 'CV_BIND=10.0.0.5' "$got" '10.0.0.5'
+
+  got="$(run_bind "$extract" "$empty_dir")"
+  assert_eq "$script" 'no tailscale' "$got" '127.0.0.1'
+
+  got="$(run_bind "$extract" "${shim_ok}:/usr/bin:/bin")"
+  assert_eq "$script" 'tailscale 100.64.0.9' "$got" '100.64.0.9'
+
+  got="$(run_bind "$extract" "${shim_empty}:/usr/bin:/bin")"
+  assert_eq "$script" 'tailscale empty' "$got" '127.0.0.1'
+
+  rm -f "$extract"
+done
+
+if [ "$fail" -ne 0 ]; then
+  echo "test-bind: FAILED"
+  exit 1
+fi
+echo "test-bind: all passed"


### PR DESCRIPTION
Fixes #7.

**What was wrong.** websockify (6080) was launched with no bind address and the HD agent defaulted `--bind` to `0.0.0.0`, so both listened on every interface. `SECURITY.md` said the bridges were loopback-only.

**Bind policy** (same `resolve_bind` in `connect-linux.sh`, `connect-mac.sh`, `hiperf-mac.sh`, `hiperf-linux.sh`; `-Bind` parameter on the two Windows scripts):
- `CV_BIND=<ip>` wins; `CV_BIND=0.0.0.0` / `CV_BIND=lan` binds every interface and prints a warning.
- Otherwise the Tailscale IPv4 when `tailscale ip -4` returns one (macOS also checks `/Applications/Tailscale.app`).
- Otherwise `127.0.0.1`.

The systemd units and LaunchAgents pass that address; `hiperf-agent.py` defaults `--bind` to `127.0.0.1`. Re-running a script rewrites its unit/plist, so existing installs migrate on re-run.

**Printed paste address** follows the bind: tailnet address plus MagicDNS name, an SSH tunnel recipe on loopback, or the LAN hostname plus a warning on `0.0.0.0`.

**Docs.** `SECURITY.md` scope notes and the README networking/security sections now state the actual model: 5900 is loopback-only, 6080/6090 are network listeners on the tailnet or loopback, transport is plaintext `ws://` with the tailnet or an SSH tunnel as the boundary, the HD token rides in the query string, the VNC password is 8 chars by protocol.

**Test.** `computer-viewer/tests/test-bind.sh` extracts `resolve_bind` from each script and checks the override, no-tailscale, tailscale-present, and tailscale-empty cases (24 assertions).

**Not done here:** TLS/`wss` mode (documented as out of scope; the tailnet is the encrypted layer). The PowerShell edits are mechanical and untested (no PowerShell on the build machine).

Verification: `bash -n` on all scripts, `python3 -m py_compile`, `--help` shows the new default, `bash computer-viewer/tests/test-bind.sh` → all passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)