### PR TITLE
compat: drop dead Bots-home gate, fix texting-style import, stamp verified build

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,9 +83,9 @@ coding agents read that file automatically.)
 
 ## Requirements
 
-- **Hermes Desktop ≥ 0.20.5**, verified through **v0.20.6** (2026.8.27,
-  including the Bot Mode redesign) — earlier builds pre-date the pane shell
-  the plugins target.
+- **Hermes Desktop ≥ 0.20.5**, verified against **v0.20.6** and a main-branch
+  build from 2026-09-05 (hermes-agent `9dd6634c56`); upstream head
+  (`14ca27fa06`, 2026-09-06) has an identical plugin contract.
 - The desktop plugins are single-file disk plugins: no build step, no core
   patches, hot-reloadable, and they fail safe (if a Hermes update renames
   internal hooks, they render stock instead of breaking).

--- a/bubble-mode/README.md
+++ b/bubble-mode/README.md
@@ -83,7 +83,7 @@ makes the bot *write* like a texter in the same chats this plugin makes
 
 ## Compatibility & upstream state
 
-- **Built and verified against Hermes Desktop v0.20.5 AND v0.20.6+ (macOS, 2026-09)** — 2.1.1 carries dual detection: the 0.20.5 tab-strip path and the 0.20.6 Bot Mode redesign path (workspace-hosted chat, gated on the stable Scheduled Jobs ownership tile so transcript remounts cannot flash the styling off).
+- **Built and verified against Hermes Desktop v0.20.5 AND v0.20.6+ (macOS, 2026-09)** — 2.1.1 carries dual detection: the 0.20.5 tab-strip path and the 0.20.6 Bot Mode redesign path (workspace-hosted chat, gated on the stable Scheduled Jobs ownership tile so transcript remounts cannot flash the styling off); also verified on a 2026-09-05 main-branch build (hermes-agent `9dd6634c56`), and upstream head (`14ca27fa06`, 2026-09-06) has an identical plugin contract.
   Also verified on a build carrying the pending upstream pane fixes
   ([hermes-agent#95956](https://github.com/NousResearch/hermes-agent/pull/95956),
   [hermes-agent#95352](https://github.com/NousResearch/hermes-agent/pull/95352))

--- a/bubble-mode/plugin.js
+++ b/bubble-mode/plugin.js
@@ -19,7 +19,6 @@ const SHOW_WORK_KEY = 'showWork'
 
 const BOTS_PANE_ID = 'hermes-bots:pane'
 const ROUTINES_PANE_ID = 'hermes-bots:routines'
-const BOTS_HOME_PANE_ID = 'plugin-workspace:hermes-bots:home'
 const BOTS_GROUP_TAB_PREFIX = 'plugin-workspace:hermes-bots:group:'
 const SESSION_TILE_TAB_PREFIX = 'session-tile:'
 const PANE_HIDDEN_ATTR = 'data-pane-hidden'
@@ -219,12 +218,6 @@ function botsPaneActive() {
   return tabSelected(BOTS_PANE_ID)
 }
 
-function botsHomeFronted() {
-  const fromSdk = paneStoreGet(BOTS_HOME_PANE_ID)
-  if (fromSdk !== undefined) return fromSdk
-  return tabSelected(BOTS_HOME_PANE_ID)
-}
-
 function groupChatFronted() {
   if (typeof document === 'undefined') return false
   const tabs = document.querySelectorAll(`[data-tree-tab^="${BOTS_GROUP_TAB_PREFIX}"]`)
@@ -322,7 +315,6 @@ function workspaceBotChatVisible() {
 
 function botModeChatVisible() {
   if (!botsPaneActive()) return false
-  if (botsHomeFronted()) return false
   if (groupChatFronted()) return false
   // v0.20.5 tab-strip path first, then the >=0.20.6 workspace path.
   if (canonicalBotChatTabSelected()) return true
@@ -505,7 +497,6 @@ export default {
     injectStyle()
 
     watchPane(BOTS_PANE_ID, scheduleSync)
-    watchPane(BOTS_HOME_PANE_ID, scheduleSync)
     watchPane(ROUTINES_PANE_ID, scheduleSync)
     watchStore(host.state?.focusedStoredSessionId || host.state?.activeSessionId, scheduleSync)
 

--- a/bubble-mode/plugin.test.mjs
+++ b/bubble-mode/plugin.test.mjs
@@ -12,7 +12,7 @@ function store(value) {
   }
 }
 
-function loadDetection({ bots = true, home = false, routines = true, transcript = false } = {}) {
+function loadDetection({ bots = true, routines = true, transcript = false } = {}) {
   const surface = {
     closest: () => null,
     getAttribute: name => {
@@ -24,7 +24,6 @@ function loadDetection({ bots = true, home = false, routines = true, transcript 
   }
   const paneValues = {
     'hermes-bots:pane': bots,
-    'plugin-workspace:hermes-bots:home': home,
     'hermes-bots:routines': routines
   }
   const document = {
@@ -62,8 +61,7 @@ test('Bubble Mode stays active while a Bot Chat transcript remounts during send'
   assert.equal(detection.botModeChatVisible(), true)
 })
 
-test('Bubble Mode still rejects Bots home and non-Bot-Chat workspaces', () => {
-  assert.equal(loadDetection({ home: true }).botModeChatVisible(), false)
+test('Bubble Mode still rejects non-Bot-Chat workspaces', () => {
   assert.equal(loadDetection({ routines: false }).botModeChatVisible(), false)
   assert.equal(loadDetection({ bots: false }).botModeChatVisible(), false)
 })

--- a/task-dock/plugin.js
+++ b/task-dock/plugin.js
@@ -21,7 +21,6 @@ const STORAGE_SNAPSHOTS = 'snapshots'
 
 const BOTS_PANE_ID = 'hermes-bots:pane'
 const ROUTINES_PANE_ID = 'hermes-bots:routines'
-const BOTS_HOME_PANE_ID = 'plugin-workspace:hermes-bots:home'
 const BOTS_GROUP_TAB_PREFIX = 'plugin-workspace:hermes-bots:group:'
 const SESSION_TILE_TAB_PREFIX = 'session-tile:'
 const PANE_HIDDEN_ATTR = 'data-pane-hidden'
@@ -318,12 +317,6 @@ function botsPaneActive() {
   return tabSelected(BOTS_PANE_ID)
 }
 
-function botsHomeFronted() {
-  const fromSdk = paneStoreGet(BOTS_HOME_PANE_ID)
-  if (fromSdk !== undefined) return fromSdk
-  return tabSelected(BOTS_HOME_PANE_ID)
-}
-
 function groupChatFronted() {
   if (typeof document === 'undefined') return false
   const tabs = document.querySelectorAll(`[data-tree-tab^="${BOTS_GROUP_TAB_PREFIX}"]`)
@@ -387,7 +380,6 @@ function workspaceBotChatVisible() {
 
 function botModeChatVisible() {
   if (!botsPaneActive()) return false
-  if (botsHomeFronted()) return false
   if (groupChatFronted()) return false
   if (canonicalBotChatTabSelected()) return true
   return workspaceBotChatVisible()
@@ -1220,7 +1212,6 @@ export default {
     injectStyle()
 
     watchPane(BOTS_PANE_ID, scheduleSync)
-    watchPane(BOTS_HOME_PANE_ID, scheduleSync)
     watchPane(ROUTINES_PANE_ID, scheduleSync)
     watchStore(host.state?.focusedStoredSessionId || host.state?.activeSessionId, scheduleSync)
     watchStore(host.state?.focusedSessionProfile, scheduleSync)

--- a/texting-style/__init__.py
+++ b/texting-style/__init__.py
@@ -68,7 +68,7 @@ def _candidate_dbs(profile_name: str) -> list:
     if env_home:
         add(env_home)
     try:
-        from hermes_cli.profiles import get_hermes_home  # type: ignore
+        from hermes_constants import get_hermes_home  # type: ignore
 
         add(get_hermes_home())
     except Exception:


### PR DESCRIPTION
Source-level audit of the kit against Hermes Desktop v0.20.6, a main-branch build from 2026-09-05 (hermes-agent `9dd6634c56`), and upstream head (`14ca27fa06`). Nothing is broken; the desktop plugin contract is identical between the last two. Three leftovers cleaned up:

- **bubble-mode, task-dock:** `plugin-workspace:hermes-bots:home` no longer exists after the hermes-bots rewrite, so `botsHomeFronted()` always returned false. Removed the constant, the function, its call site, the `watchPane` line, and the test stub.
- **texting-style:** `from hermes_cli.profiles import get_hermes_home` never resolved (hidden by try/except); now `hermes_constants`. `hermes plugins doctor --ci` passes.
- **READMEs:** verified-build statement updated.

Verification: `node --check`, `node --test` (13 pass), `python3 -m py_compile`, doctor OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)