### PR TITLE
computer-viewer: load the vendored noVNC from vendor/ where the installer puts it

### DIFF
--- a/computer-viewer/plugin.js
+++ b/computer-viewer/plugin.js
@@ -1393,7 +1393,8 @@ function textFromReadFile(payload) {
 function vendoredRfbPath(root) {
   const sep = root.includes('\\') ? '\\' : '/'
   const base = root.endsWith('\\') || root.endsWith('/') ? root.slice(0, -1) : root
-  return base + sep + 'computer-viewer' + sep + 'novnc-rfb.mjs'
+  // Must match scripts/manifest-files.txt: computer-viewer/vendor/novnc-rfb.mjs
+  return base + sep + 'computer-viewer' + sep + 'vendor' + sep + 'novnc-rfb.mjs'
 }
 
 async function loadVendoredRFB() {

--- a/computer-viewer/plugin.test.mjs
+++ b/computer-viewer/plugin.test.mjs
@@ -313,8 +313,14 @@ function fakeBridge({ text, missing } = {}) {
   const source = text === undefined ? VENDOR_RFB_SOURCE : text
   return {
     desktopPluginsRoot: async () => '/tmp/hermes-home/desktop-plugins',
-    readFileText: async filePath => {
-      assert.match(filePath, /computer-viewer[/\\]novnc-rfb\.mjs$/)
+    readPluginSource: async filePath => {
+      // Drift guard: the plugin must look exactly where the installer puts the
+      // file, i.e. the manifest's relative path under desktop-plugins.
+      const manifestRel = fs
+        .readFileSync(new URL('../scripts/manifest-files.txt', import.meta.url), 'utf8')
+        .split('\n')
+        .find(line => line.endsWith('novnc-rfb.mjs'))
+      assert.equal(filePath, '/tmp/hermes-home/desktop-plugins/' + manifestRel)
       if (missing) throw new Error('ENOENT')
       return {
         binary: false,


### PR DESCRIPTION
Bug: `vendoredRfbPath()` built `<root>/computer-viewer/novnc-rfb.mjs`, but `install.sh` and the manifest place the bundle at `computer-viewer/vendor/novnc-rfb.mjs`. Every install therefore reported the file missing and fell through to the CDN. The unit test stub encoded the same wrong path, so it passed.

Fix: path corrected; the test stub now derives the expected path from `scripts/manifest-files.txt` (the installer's source of truth) and fails if the two ever diverge. The stub also uses `readPluginSource`, which is what production prefers.

Found by the Grok 4.6 review pass. Test count unchanged (14), all pass; fails before the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)