### PR TITLE
python plugins: cancellation-safe lock, streaming screenshot cap, retry failed lookups

### DIFF
--- a/computer-viewer/agent-plugin/orgo-computer/tests/test_hands.py
+++ b/computer-viewer/agent-plugin/orgo-computer/tests/test_hands.py
@@ -55,17 +55,48 @@ TINY_JPEG = bytes.fromhex(
 
 
 class FakeResponse:
-    def __init__(self, status=200, payload=None, content=b"", content_type="application/json"):
+    def __init__(
+        self,
+        status=200,
+        payload=None,
+        content=b"",
+        content_type="application/json",
+        chunks=None,
+        content_length=None,
+    ):
         self.status_code = status
         self._payload = payload
         self.content = content
         self.is_success = 200 <= status < 300
         self.headers = {"content-type": content_type}
+        if content_length is not None:
+            self.headers["content-length"] = str(content_length)
+        self._chunks = chunks
+        self.read_started = False
 
     def json(self):
         if self._payload is None:
             raise ValueError("no json")
         return self._payload
+
+    async def aiter_bytes(self):
+        """Mimic httpx: the body is only produced once iteration starts."""
+        self.read_started = True
+        for chunk in self._chunks if self._chunks is not None else [self.content]:
+            yield chunk
+
+
+class FakeStream:
+    """`async with client.stream(...) as resp:` for FakeClient."""
+
+    def __init__(self, response):
+        self.response = response
+
+    async def __aenter__(self):
+        return self.response
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
 
 
 class FakeClient:
@@ -74,11 +105,19 @@ class FakeClient:
         self.posts = []
         self.gets = []
         self.get_headers = []
+        self.streams = []
 
     async def get(self, url, headers=None):
         self.gets.append(url)
         self.get_headers.append(headers or {})
         return self.router("GET", url, None)
+
+    def stream(self, method, url, headers=None):
+        self.gets.append(url)
+        self.get_headers.append(headers or {})
+        response = self.router(method, url, None)
+        self.streams.append(response)
+        return FakeStream(response)
 
     async def post(self, url, headers=None, json=None):
         self.posts.append((url, json))
@@ -387,6 +426,134 @@ class HandsTests(unittest.TestCase):
         fake = FakeHttpx(lambda *a, **k: None)
         with patch.object(tools, "_import_httpx", return_value=fake):
             self.assertIs(tools._client_kwargs(5.0)["follow_redirects"], False)
+
+    def test_screenshot_rejects_oversized_content_length_without_reading(self):
+        body = FakeResponse(
+            200,
+            payload=None,
+            content=b"x" * 16,
+            content_type="image/jpeg",
+            content_length=tools.MAX_SCREENSHOT_BYTES + 1,
+        )
+
+        def router(method, url, body_json):
+            if url.endswith("/screenshot"):
+                return FakeResponse(200, {"success": True, "image": "/api/storage/x.jpg"})
+            return body
+
+        fake = FakeHttpx(router)
+        with patch.object(tools, "_import_httpx", return_value=fake):
+            raw = asyncio.run(tools.orgo_computer_screenshot({}))
+        self.assertIn("too large to attach", raw)
+        self.assertFalse(body.read_started)
+
+    def test_screenshot_aborts_when_chunks_exceed_cap(self):
+        chunk = b"x" * 100_000
+        count = (tools.MAX_SCREENSHOT_BYTES // len(chunk)) + 2
+        body = FakeResponse(
+            200,
+            payload=None,
+            content_type="image/jpeg",
+            chunks=[chunk] * count,
+        )
+
+        def router(method, url, body_json):
+            if url.endswith("/screenshot"):
+                return FakeResponse(200, {"success": True, "image": "/api/storage/x.jpg"})
+            return body
+
+        fake = FakeHttpx(router)
+        with patch.object(tools, "_import_httpx", return_value=fake):
+            raw = asyncio.run(tools.orgo_computer_screenshot({}))
+        self.assertIn("too large to attach", raw)
+        self.assertTrue(body.read_started)
+
+    def test_screenshot_streams_chunked_body(self):
+        half = len(TINY_JPEG) // 2
+        body = FakeResponse(
+            200,
+            payload=None,
+            content_type="image/jpeg",
+            chunks=[TINY_JPEG[:half], b"", TINY_JPEG[half:]],
+            content_length=len(TINY_JPEG),
+        )
+
+        def router(method, url, body_json):
+            if url.endswith("/screenshot"):
+                return FakeResponse(200, {"success": True, "image": "/api/storage/x.jpg"})
+            return body
+
+        fake = FakeHttpx(router)
+        with patch.object(tools, "_import_httpx", return_value=fake):
+            result = asyncio.run(tools.orgo_computer_screenshot({}))
+        self.assertTrue(result["_multimodal"])
+        self.assertIn("1x1", result["text_summary"])
+
+    def _hold_lock_file(self):
+        """Take the flock on the run-lock file from a second descriptor."""
+        handle = tools._lock_path(PIN).open("a+", encoding="utf-8")
+        tools.fcntl.flock(handle.fileno(), tools.fcntl.LOCK_EX | tools.fcntl.LOCK_NB)
+        return handle
+
+    def test_cancelled_wait_releases_the_run_lock(self):
+        if tools.fcntl is None:
+            self.skipTest("flock unavailable")
+        holder = self._hold_lock_file()
+
+        async def main():
+            lock = tools._ComputerRunLock(PIN, 30.0)
+            task = asyncio.ensure_future(lock.__aenter__())
+            await asyncio.sleep(0.4)
+            self.assertTrue(tools._in_process_lock(PIN).locked())
+            task.cancel()
+            with self.assertRaises(asyncio.CancelledError):
+                await task
+            self.assertIsNone(lock._file)
+
+        try:
+            asyncio.run(main())
+            self.assertFalse(tools._in_process_lock(PIN).locked())
+        finally:
+            tools.fcntl.flock(holder.fileno(), tools.fcntl.LOCK_UN)
+            holder.close()
+        self.assertFalse(tools._run_lock_is_held(PIN))
+
+    def test_run_lock_timeout_raises_busy_not_attribute_error(self):
+        if tools.fcntl is None:
+            self.skipTest("flock unavailable")
+        holder = self._hold_lock_file()
+
+        async def main():
+            lock = tools._ComputerRunLock(PIN, 0.0)
+            with self.assertRaises(tools.OrgoAgentRequestError) as caught:
+                await lock.__aenter__()
+            self.assertIn("Another agent is controlling", str(caught.exception))
+
+        try:
+            asyncio.run(main())
+        finally:
+            tools.fcntl.flock(holder.fileno(), tools.fcntl.LOCK_UN)
+            holder.close()
+        self.assertFalse(tools._in_process_lock(PIN).locked())
+        self.assertFalse(tools._run_lock_is_held(PIN))
+
+    def test_run_lock_open_failure_releases_process_lock(self):
+        if tools.fcntl is None:
+            self.skipTest("flock unavailable")
+
+        def boom(*args, **kwargs):
+            raise OSError("cannot open lock file")
+
+        async def main():
+            lock = tools._ComputerRunLock(PIN, 5.0)
+            lock._path = SimpleNamespace(open=boom)
+            with self.assertRaises(OSError):
+                await lock.__aenter__()
+            self.assertIsNone(lock._file)
+
+        asyncio.run(main())
+        self.assertFalse(tools._in_process_lock(PIN).locked())
+        self.assertFalse(tools._run_lock_is_held(PIN))
 
     def test_schemas_exist(self):
         self.assertEqual(schemas.ORGO_COMPUTER_CLICK["name"], "orgo_computer_click")

--- a/computer-viewer/agent-plugin/orgo-computer/tools.py
+++ b/computer-viewer/agent-plugin/orgo-computer/tools.py
@@ -62,6 +62,7 @@ PIN_401_ERROR = (
     "Orgo rejected the configured API key. Fix ORGO_API_KEY in this profile."
 )
 MAX_SCREENSHOT_BYTES = 1_500_000
+TOO_LARGE_ERROR = "Screenshot is too large to attach."
 MAX_TYPE_LENGTH = 4000
 HANDS_INPUT_TOOLS = frozenset(
     {"orgo_computer_click", "orgo_computer_type", "orgo_computer_key"}
@@ -562,26 +563,41 @@ class _ComputerRunLock(AbstractAsyncContextManager[None]):
             _log_flock_skip()
             return None
 
-        self._file = self._path.open("a+", encoding="utf-8")
+        handle: Any = None
+        locked = False
         try:
+            handle = self._path.open("a+", encoding="utf-8")
             while True:
                 try:
-                    fcntl.flock(self._file.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
-                    return None
+                    fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+                    locked = True
+                    break
                 except BlockingIOError:
                     if time.monotonic() >= deadline:
-                        self._file.close()
-                        self._file = None
-                        proc.release()
-                        self._proc = None
                         _busy()
                     await asyncio.sleep(0.25)
-        except Exception:
-            self._file.close()
+        except BaseException:
+            # Cancellation counts: release exactly what was acquired, then
+            # re-raise so the caller still sees the original failure.
+            if locked and handle is not None:
+                try:
+                    fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+                except Exception:
+                    logger.debug("flock unlock failed", exc_info=True)
+            if handle is not None:
+                try:
+                    handle.close()
+                except Exception:
+                    pass
             self._file = None
-            proc.release()
+            try:
+                proc.release()
+            except RuntimeError:
+                pass
             self._proc = None
             raise
+        self._file = handle
+        return None
 
     async def __aexit__(self, exc_type: Any, exc: Any, traceback: Any) -> None:
         if self._file is not None and fcntl is not None:
@@ -1465,6 +1481,20 @@ async def _http_client(timeout: float) -> Any:
     return httpx, httpx.AsyncClient(**_client_kwargs(timeout))
 
 
+def _declared_length(response: Any) -> int:
+    """Content-Length as an int, or -1 when absent or unparseable."""
+    try:
+        raw = response.headers.get("content-length")
+    except Exception:
+        return -1
+    if raw is None:
+        return -1
+    try:
+        return int(str(raw).strip())
+    except (TypeError, ValueError):
+        return -1
+
+
 async def _take_screenshot() -> dict[str, Any]:
     api_key = _require_api_key()
     computer_id = _require_computer_id()
@@ -1492,21 +1522,31 @@ async def _take_screenshot() -> dict[str, Any]:
             if not _url_scheme_allowed(parsed_image):
                 raise OrgoAgentRequestError("Orgo returned an insecure screenshot URL.")
             headers = {"Accept": "image/*"}
-        image_resp = await client.get(image_url, headers=headers)
-        if not image_resp.is_success:
-            _raise_hands_http(image_resp.status_code, None, "screenshot")
-        content_type = ""
-        try:
-            content_type = str(image_resp.headers.get("content-type") or "")
-        except Exception:
+        async with client.stream("GET", image_url, headers=headers) as image_resp:
+            if not image_resp.is_success:
+                _raise_hands_http(image_resp.status_code, None, "screenshot")
             content_type = ""
-        if content_type and "image/" not in content_type.lower():
-            raise OrgoAgentRequestError("Orgo screenshot was not an image.")
-        data = bytes(image_resp.content or b"")
+            try:
+                content_type = str(image_resp.headers.get("content-type") or "")
+            except Exception:
+                content_type = ""
+            if content_type and "image/" not in content_type.lower():
+                raise OrgoAgentRequestError("Orgo screenshot was not an image.")
+            if _declared_length(image_resp) > MAX_SCREENSHOT_BYTES:
+                # Refuse before a single byte of the body is read.
+                raise OrgoAgentRequestError(TOO_LARGE_ERROR)
+            chunks: list[bytes] = []
+            total = 0
+            async for chunk in image_resp.aiter_bytes():
+                if not chunk:
+                    continue
+                total += len(chunk)
+                if total > MAX_SCREENSHOT_BYTES:
+                    raise OrgoAgentRequestError(TOO_LARGE_ERROR)
+                chunks.append(bytes(chunk))
+        data = b"".join(chunks)
         if not data:
             raise OrgoAgentRequestError("Orgo screenshot was empty.")
-        if len(data) > MAX_SCREENSHOT_BYTES:
-            raise OrgoAgentRequestError("Screenshot is too large to attach.")
     except httpx.TimeoutException as exc:
         raise OrgoAgentRequestError("The Orgo screenshot timed out.") from exc
     except httpx.HTTPError as exc:

--- a/texting-style/__init__.py
+++ b/texting-style/__init__.py
@@ -18,11 +18,16 @@ from __future__ import annotations
 
 import os
 import sqlite3
+import time
 from pathlib import Path
 
 # Must match tools/bot_mode_probe.py BOT_CHAT_TITLE (the desktop's
 # createCanonicalChat title and the `-c "Bot Chat"` resume target).
 BOT_CHAT_TITLE = "Bot Chat"
+
+# A failed session lookup (missing/locked/broken state.db) is retried after
+# this many seconds instead of being cached as "not a Bot Chat" forever.
+LOOKUP_RETRY_SECONDS = 30.0
 
 DOCTRINE = """## Texting register
 
@@ -91,12 +96,14 @@ def _candidate_dbs(profile_name: str) -> list:
 _db_for_session: dict = {}
 
 
-def _session_row(profile_name: str, session_id: str, columns: str) -> tuple:
+def _session_row(profile_name: str, session_id: str, columns: str):
     """Read columns for a session, searching candidate state.dbs until the
-    session id is found (cached). Empty tuple on any failure -- never crash
-    a prompt build."""
+    session id is found (cached). Returns the row as a tuple, or None when the
+    lookup could not be completed (no readable state.db, a locked or broken
+    database, or the session id was not found anywhere). Never crashes a
+    prompt build -- callers treat None as "unknown", not as "no"."""
     if not session_id:
-        return ()
+        return None
     known = _db_for_session.get(session_id)
     dbs = [known] if known else _candidate_dbs(profile_name)
     for db in dbs:
@@ -115,12 +122,16 @@ def _session_row(profile_name: str, session_id: str, columns: str) -> tuple:
                 _db_for_session.clear()
             _db_for_session[session_id] = db
             return tuple(row)
-    return ()
+    return None
 
 
-def _session_title(profile_name: str, session_id: str) -> str:
+def _session_title(profile_name: str, session_id: str):
+    """The session title, '' when the row exists but has no title, or None
+    when the lookup failed (so the caller can retry later)."""
     row = _session_row(profile_name, session_id, "title")
-    return str(row[0]) if row and row[0] is not None else ""
+    if row is None:
+        return None
+    return str(row[0]) if row[0] is not None else ""
 
 
 def _stored_prompt_has_doctrine(session_id: str) -> bool:
@@ -151,7 +162,7 @@ def register(ctx) -> None:
                 str(info.get("profile_name", "") or ""),
                 str(info.get("session_id", "") or ""),
             )
-            if title.strip() != BOT_CHAT_TITLE:
+            if title is None or title.strip() != BOT_CHAT_TITLE:
                 return ""
         text = DOCTRINE
         extra = str(_cfg("extra_rules", "") or "").strip()
@@ -174,15 +185,30 @@ def register(ctx) -> None:
     # per-turn context instead. Once an epoch rebuild bakes the section in,
     # the hook goes silent automatically.
     _title_cache: dict = {}
+    _title_retry_after: dict = {}
 
     def _is_bot_chat(session_id: str) -> bool:
+        """Cache confirmed answers forever; a failed lookup is only remembered
+        for LOOKUP_RETRY_SECONDS so a transient database problem cannot mute
+        the plugin for the life of the process."""
         if session_id in _title_cache:
             return _title_cache[session_id]
+        now = time.monotonic()
+        retry_after = _title_retry_after.get(session_id)
+        if retry_after is not None and now < retry_after:
+            return False
         title = _session_title("", session_id)
+        if title is None:
+            if len(_title_retry_after) > 512:
+                _title_retry_after.clear()
+            _title_retry_after[session_id] = now + LOOKUP_RETRY_SECONDS
+            _debug(f"lookup failed, retrying later (session={session_id!r})")
+            return False
+        _title_retry_after.pop(session_id, None)
         result = title.strip() == BOT_CHAT_TITLE
-        _title_cache[session_id] = result
         if len(_title_cache) > 512:
             _title_cache.clear()
+        _title_cache[session_id] = result
         return result
 
     def _debug(msg: str) -> None:

--- a/texting-style/tests/test_backfill.py
+++ b/texting-style/tests/test_backfill.py
@@ -1,0 +1,164 @@
+"""Tests for the texting-style backfill hook and its session-title cache."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+PLUGIN_DIR = Path(__file__).resolve().parents[1]
+
+
+def _load_plugin():
+    spec = importlib.util.spec_from_file_location(
+        "texting_style_plugin", PLUGIN_DIR / "__init__.py"
+    )
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["texting_style_plugin"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+plugin = _load_plugin()
+
+
+class FakeCursor:
+    def __init__(self, row):
+        self._row = row
+
+    def fetchone(self):
+        return self._row
+
+
+class FakeConn:
+    """Answers `SELECT <column> FROM sessions WHERE id = ?` from a dict."""
+
+    def __init__(self, values):
+        self._values = values
+        self.closed = False
+
+    def execute(self, sql, params):
+        column = sql.split("SELECT ", 1)[1].split(" FROM", 1)[0].strip()
+        if column not in self._values:
+            return FakeCursor(None)
+        return FakeCursor((self._values[column],))
+
+    def close(self):
+        self.closed = True
+
+
+class FakeCtx:
+    def __init__(self, config=None):
+        self.config = config or {}
+        self.hooks = {}
+        self.section = None
+
+    def get_config(self, key, default=None):
+        return self.config.get(key, default)
+
+    def register_system_prompt_section(self, name, fn, **kwargs):
+        self.section = fn
+
+    def register_hook(self, name, fn):
+        self.hooks[name] = fn
+
+
+class BackfillTests(unittest.TestCase):
+    def setUp(self):
+        plugin._db_for_session.clear()
+        self._retry = getattr(plugin, "LOOKUP_RETRY_SECONDS", 30.0)
+        self.ctx = FakeCtx()
+        plugin.register(self.ctx)
+        self.backfill = self.ctx.hooks["pre_llm_call"]
+        patcher = patch.object(
+            plugin, "_candidate_dbs", return_value=[Path("/nonexistent/state.db")]
+        )
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def tearDown(self):
+        plugin.LOOKUP_RETRY_SECONDS = self._retry
+        plugin._db_for_session.clear()
+
+    def _connect(self, values):
+        return lambda *a, **k: FakeConn(values)
+
+    def _raise(self, *a, **k):
+        raise plugin.sqlite3.OperationalError("database is locked")
+
+    def test_transient_failure_is_not_cached_forever(self):
+        plugin.LOOKUP_RETRY_SECONDS = 0.0
+        with patch.object(plugin.sqlite3, "connect", side_effect=self._raise):
+            self.assertIsNone(self.backfill(session_id="s1"))
+        with patch.object(
+            plugin.sqlite3,
+            "connect",
+            side_effect=self._connect({"title": "Bot Chat", "system_prompt": ""}),
+        ):
+            result = self.backfill(session_id="s1")
+        self.assertIsInstance(result, dict)
+        self.assertIn("## Texting register", result["context"])
+
+    def test_failure_is_negatively_cached_for_the_retry_window(self):
+        calls = []
+
+        def raising(*a, **k):
+            calls.append(1)
+            raise plugin.sqlite3.OperationalError("database is locked")
+
+        with patch.object(plugin.sqlite3, "connect", side_effect=raising):
+            self.assertIsNone(self.backfill(session_id="s2"))
+            self.assertIsNone(self.backfill(session_id="s2"))
+        self.assertEqual(len(calls), 1)
+
+    def test_confirmed_empty_title_stays_cached(self):
+        with patch.object(
+            plugin.sqlite3, "connect", side_effect=self._connect({"title": ""})
+        ):
+            self.assertIsNone(self.backfill(session_id="s3"))
+        # Even a later Bot Chat title does not re-open the question: the first
+        # answer was confirmed, so no second lookup happens.
+        with patch.object(
+            plugin.sqlite3, "connect", side_effect=self._raise
+        ) as never_used:
+            self.assertIsNone(self.backfill(session_id="s3"))
+            self.assertEqual(never_used.call_count, 0)
+
+    def test_session_title_distinguishes_failure_from_empty(self):
+        with patch.object(plugin.sqlite3, "connect", side_effect=self._raise):
+            self.assertIsNone(plugin._session_title("", "s4"))
+        with patch.object(
+            plugin.sqlite3, "connect", side_effect=self._connect({"title": None})
+        ):
+            self.assertEqual(plugin._session_title("", "s4"), "")
+
+    def test_section_stays_empty_when_lookup_fails(self):
+        with patch.object(plugin.sqlite3, "connect", side_effect=self._raise):
+            self.assertEqual(self.ctx.section({"session_id": "s5"}), "")
+
+    def test_backfill_skips_when_prompt_already_has_doctrine(self):
+        with patch.object(
+            plugin.sqlite3,
+            "connect",
+            side_effect=self._connect(
+                {"title": "Bot Chat", "system_prompt": plugin.DOCTRINE}
+            ),
+        ):
+            self.assertIsNone(self.backfill(session_id="s6"))
+
+    def test_backfill_skips_history_that_already_carries_doctrine(self):
+        history = [{"role": "system", "content": plugin.DOCTRINE}]
+        with patch.object(
+            plugin.sqlite3,
+            "connect",
+            side_effect=self._connect({"title": "Bot Chat", "system_prompt": ""}),
+        ):
+            self.assertIsNone(
+                self.backfill(session_id="s7", conversation_history=history)
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Round-2 review fixes (Codex items 3, 9, 12). Lock cleanup covers BaseException and releases only what was acquired; screenshot download is streamed with the cap enforced before and during the read; texting-style no longer caches a transient lookup failure as 'not a Bot Chat'. 6 new orgo tests (27 total), new texting-style suite (7). Doctor passes for both plugins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)