### PR TITLE
bubble-mode, task-dock, bot-sections: stale-read guard, theme tokens, label match, shared gate tests

### DIFF
--- a/bot-sections/plugin.test.mjs
+++ b/bot-sections/plugin.test.mjs
@@ -1,0 +1,166 @@
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import test from 'node:test'
+import vm from 'node:vm'
+
+const pluginPath = new URL('./plugin.js', import.meta.url)
+const SOURCE = fs.readFileSync(pluginPath, 'utf8')
+
+const HOOKS =
+  '\nglobalThis.__testHooks = { applyAssignData, applyAssignFileText, findBotsPaneRoots,' +
+  ' sectionForKey, sectionLadder, getOverrides: () => overrides, getCustomSections: () => customSections }\n'
+
+function classList(...names) {
+  const set = new Set(names)
+  return { contains: name => set.has(name) }
+}
+
+/** A roster element. `hiddenPane` makes `inHiddenPane()` true for it. */
+function el({ className = '', textContent = '', classes = [], parentElement = null, hiddenPane = false } = {}) {
+  return {
+    className,
+    classList: classList(...classes),
+    closest: selector => (hiddenPane && selector === '[data-pane-hidden]' ? { id: 'hidden-pane' } : null),
+    parentElement,
+    textContent
+  }
+}
+
+function load({ spans = [] } = {}) {
+  const warnings = []
+  const context = {
+    __host: { state: {} },
+    CSS: { escape: value => value },
+    console: { warn: message => warnings.push(message) },
+    document: {
+      body: { classList: { add() {}, contains: () => false, remove() {} } },
+      querySelector: () => null,
+      querySelectorAll: selector => (selector === 'span' ? spans : [])
+    },
+    globalThis: null,
+    setTimeout: () => 0
+  }
+  context.globalThis = context
+
+  const source = SOURCE.replace(
+    "import { PALETTE_AREA, host } from '@hermes/plugin-sdk'",
+    "const PALETTE_AREA = 'palette'; const host = globalThis.__host"
+  )
+    .replace('export default {', 'globalThis.__plugin = {')
+    .concat(HOOKS)
+
+  vm.runInNewContext(source, vm.createContext(context), { filename: pluginPath.pathname })
+  return { ...context.__testHooks, warnings }
+}
+
+test('a valid bot-sections.json creates its sections and assigns its bots', () => {
+  const kit = load()
+
+  kit.applyAssignFileText(JSON.stringify({ sections: ['Airbnb Ops'], assign: { alfred: 'Airbnb Ops' } }))
+
+  assert.deepEqual({ ...kit.getOverrides() }, { alfred: 'Airbnb Ops' })
+  assert.ok(kit.sectionLadder().includes('Airbnb Ops'))
+  assert.equal(kit.sectionForKey('alfred'), 'Airbnb Ops')
+  assert.equal(kit.sectionForKey('@Alfred'), 'Airbnb Ops')
+  assert.equal(kit.sectionForKey('nobody'), 'Unassigned')
+})
+
+test('a section named only in assign is created on the spot', () => {
+  const kit = load()
+
+  kit.applyAssignFileText(JSON.stringify({ assign: { pricey: 'Revenue' } }))
+
+  assert.ok(kit.getCustomSections().includes('Revenue'))
+  assert.equal(kit.sectionForKey('pricey'), 'Revenue')
+})
+
+test('malformed bot-sections.json is ignored, warned once, and leaves the layout alone', () => {
+  const kit = load()
+
+  kit.applyAssignFileText(JSON.stringify({ assign: { alfred: 'Ops' } }))
+  kit.applyAssignFileText('{ not json')
+  kit.applyAssignFileText('{ not json')
+
+  assert.deepEqual({ ...kit.getOverrides() }, { alfred: 'Ops' })
+  assert.equal(kit.warnings.length, 1)
+  assert.match(kit.warnings[0], /malformed bot-sections\.json/)
+})
+
+test('payloads that are not objects never throw and never move a bot', () => {
+  const kit = load()
+
+  kit.applyAssignFileText(JSON.stringify({ assign: { alfred: 'Ops' } }))
+  for (const raw of ['null', '[]', '"text"', '42']) kit.applyAssignFileText(raw)
+
+  assert.deepEqual({ ...kit.getOverrides() }, { alfred: 'Ops' })
+})
+
+test('unknown bot names are recorded verbatim; junk entries are dropped', () => {
+  const kit = load()
+
+  kit.applyAssignFileText(
+    JSON.stringify({
+      assign: {
+        'not-a-real-bot': 'Ops',
+        '  MixedCase  ': 'Ops',
+        blank: '',
+        '': 'Ops',
+        numeric: 7,
+        parked: 'Unassigned'
+      }
+    })
+  )
+
+  assert.deepEqual({ ...kit.getOverrides() }, {
+    'not-a-real-bot': 'Ops',
+    mixedcase: 'Ops',
+    parked: 'Unassigned'
+  })
+  // An unknown bot still resolves — the roster simply may never show it.
+  assert.equal(kit.sectionForKey('not-a-real-bot'), 'Ops')
+  assert.equal(kit.sectionForKey('parked'), 'Unassigned')
+  assert.equal(kit.sectionLadder().includes('Unassigned'), true)
+})
+
+test('findBotsPaneRoots() takes the "Bots" heading and skips native row headers', () => {
+  const root = el({ classes: ['flex', 'h-full', 'flex-col'] })
+  const listWrap = el({ parentElement: root })
+  const anchor = el({
+    className: 'text-xs font-medium uppercase tracking-wider',
+    parentElement: listWrap,
+    textContent: 'Bots'
+  })
+
+  // A native roster row button whose label happens to read "Bots": no
+  // uppercase/tracking heading classes, so it must not seed a second root.
+  const rowRoot = el({ classes: ['flex', 'h-full', 'flex-col'] })
+  const rowButton = el({ parentElement: rowRoot })
+  const rowLabel = el({ className: 'truncate font-medium', parentElement: rowButton, textContent: 'Bots' })
+
+  // The same heading inside a collapsed pane is ignored too.
+  const hiddenRoot = el({ classes: ['flex', 'h-full', 'flex-col'], hiddenPane: true })
+  const hiddenWrap = el({ parentElement: hiddenRoot, hiddenPane: true })
+  const hiddenAnchor = el({
+    className: 'uppercase tracking-wider',
+    parentElement: hiddenWrap,
+    textContent: 'Bots',
+    hiddenPane: true
+  })
+
+  const kit = load({ spans: [anchor, rowLabel, hiddenAnchor] })
+  const roots = kit.findBotsPaneRoots()
+
+  assert.equal(roots.length, 1)
+  assert.equal(roots[0], root)
+})
+
+test('findBotsPaneRoots() falls back to the grandparent when no flex column is found', () => {
+  const grandparent = el({})
+  const parent = el({ parentElement: grandparent })
+  const anchor = el({ className: 'uppercase tracking-wider', parentElement: parent, textContent: 'Bots' })
+
+  const roots = load({ spans: [anchor] }).findBotsPaneRoots()
+
+  assert.equal(roots.length, 1)
+  assert.equal(roots[0], grandparent)
+})

--- a/bubble-mode/README.md
+++ b/bubble-mode/README.md
@@ -107,17 +107,23 @@ makes the bot *write* like a texter in the same chats this plugin makes
 
 ## Colors
 
-Tuned for the dark theme, sampled from Grok Bot:
+Bubbles read from Hermes' own theme tokens, so they follow the light and dark
+themes instead of pinning the dark palette. The hexes sampled from Grok Bot
+stay as fallbacks for hosts that don't publish the tokens.
 
-| Surface | Color |
-|---|---|
-| Your bubble (right) | `#4a4a4e`, ink `#f2f2f3` |
-| Agent bubble (left) | `#2b2b2e`, ink `#e8e8ea` |
-| Radius | `18px`, `4px` tail on the inner corner |
-| Typing pill | `#2b2b2e`, 6px dots, 16px radius |
+| Surface | Token | Dark fallback |
+|---|---|---|
+| Your bubble (right) | `--ui-bg-elevated` mixed with `--ui-text-primary` | `#4a4a4e`, ink `#f2f2f3` |
+| Agent bubble (left) | `--ui-chat-bubble-background`, ink `--ui-text-primary` | `#2b2b2e`, ink `#e8e8ea` |
+| Typing pill | `--ui-chat-bubble-background`, dots `--ui-text-tertiary` / `--ui-text-secondary` | `#2b2b2e`, `#6b6b70` / `#b9b9bf` |
+| Radius | — | `18px`, `4px` tail on the inner corner |
+
+The plugin only *reads* `--ui-chat-bubble-background`; it never redefines it,
+since that token is shared with the rest of the app.
 
 Want different colors? They live in one obvious `CSS` block at the top of
-`plugin.js` — edit the hex values and reload plugins.
+`plugin.js` — edit the fallback hex values, or point the `var(...)` at your
+own token, and reload plugins.
 
 ## Repository layout
 
@@ -140,7 +146,10 @@ so Bubble Mode reconstructs the question from public signals:
 `host.paneVisibility('hermes-bots:pane')`, the Bots home / group-chat tab
 state, and — since 1.2.0 — the selected session tab's label: only the tab
 titled **"Bot Chat"** (the desktop's canonical per-bot conversation, the same
-title Hermes core gates on in `tools/bot_mode_probe.py`) gets the look.
+title Hermes core gates on in `tools/bot_mode_probe.py`) gets the look. The
+caption is matched as "Bot Chat" followed by anything that isn't a letter, so
+the desktop's own decorations ("Bot Chat, 2 unread", a close glyph) still
+count while a differently named chat ("Bot Chats") does not.
 Since 1.4.0 the plugin also remembers tab ids it has seen correctly labeled,
 so a desktop tab-caption scramble can't turn the styling off. The full
 derivation — including the signals that looked tempting and were rejected —

--- a/bubble-mode/docs/BUILD-NOTES.md
+++ b/bubble-mode/docs/BUILD-NOTES.md
@@ -212,10 +212,10 @@ Setting: `ctx.storage` key `enabled`, default `true`.
 | Surface | Why we don't touch it |
 |---|---|
 | Sessions view | Bots pane visibility is false → body class off. CSS never matches. |
-| Sessions primary ChatView | `workspaceMode: 'sessions'` pane is filtered out in Bot Mode; selector also skips `data-composer-target="main"`. |
+| Sessions primary ChatView | `workspaceMode: 'sessions'` pane is filtered out in Bot Mode, and the body class is only ever on while the gate below says a canonical Bot Chat owns the workspace. The CSS itself does **not** skip `data-composer-target="main"` — it never needs to, because the class is off. |
 | `::card` / artifact / code cards | Excluded by slot + `:has()` split. |
 | computer-viewer pane | No `aui_*` message slots. Class toggle does not register panes or bind keys. |
-| Streaming | CSS only. MutationObserver `attributeFilter` ignores class/text; `childList` is rAF-coalesced and the class is toggled only on boolean change. No wrappers, no React, no layout JS on token flush. |
+| Streaming | CSS only. MutationObserver `attributeFilter` ignores class; `characterData` and `childList` are rAF-coalesced and the class is toggled only on boolean change. No wrappers, no React, no layout JS on token flush. |
 | Sticky human clamp | We do not change `position`, `--human-msg-full`, or clamp classes. |
 
 ---
@@ -229,14 +229,20 @@ Setting: `ctx.storage` key `enabled`, default `true`.
 
 ---
 
-## 9. Watcher wiring (mirrors hermes-bots register())
+## 9. The gate as shipped, and its watcher wiring
 
-hermes-bots listens to:
+`botModeChatVisible()` is exactly four checks, in this order:
 
-- `host.paneVisibility('hermes-bots:pane')`
-- `host.paneVisibility(BOTS_HOME_PANE_ID)`
-- `host.state.focusedStoredSessionId || host.state.activeSessionId`
+1. `botsPaneActive()` — `host.paneVisibility('hermes-bots:pane')`, falling back to the tab's `aria-selected` when the SDK has no pane store. False → off.
+2. `groupChatFronted()` — any selected `plugin-workspace:hermes-bots:group:*` tab. True → off.
+3. **v0.20.5 canonical-tab path** — a selected `session-tile:*` tab captioned `Bot Chat` (`aria-label` first, then `textContent`; normalized, and matched as `bot chat` followed by a non-letter so `Bot Chat, 2 unread` counts and `Bot Chats` does not). Tab ids seen with that caption are remembered in storage, so a caption scramble after a serve restart keeps the styling.
+4. **>=0.20.6 routines-pane path** — `host.paneVisibility('hermes-bots:routines') === true`. hermes-bots seats the Scheduled Jobs tile only while a real bot chat owns the workspace, so that bit is the whole public `botChatOwnsWorkspace()`.
 
-This plugin listens to the same three, plus a document MutationObserver on `data-pane-hidden`, `aria-selected`, `data-tree-tab`, `data-chat-surface`, `data-composer-target`, `data-session-anchor` so tab-fronting that does not move focus still flips the class.
+Not watched, deliberately:
+
+- **No Bots-home pane watch.** hermes-bots reads `host.paneVisibility(BOTS_HOME_PANE_ID)`; this plugin does not need it. Bots home has no routines pane and no `Bot Chat` tab selected, so checks 3 and 4 already return false there.
+- **No chat-surface / transcript inspection.** React removes and remounts the transcript on send; treating that as a mode change flashed the stock UI.
+
+Watchers: `host.paneVisibility('hermes-bots:pane')`, `host.paneVisibility('hermes-bots:routines')`, `host.state.focusedStoredSessionId || host.state.activeSessionId`, plus a document MutationObserver on `data-pane-hidden`, `aria-selected`, `aria-label`, `data-tree-tab` with `characterData: true`, so tab-fronting or a late caption update that does not move focus still flips the class.
 
 Style element id: `hermes-bubble-mode-style`. Body class: `hermes-bubble-mode`. Both removed on `ctx.onDispose`.

--- a/bubble-mode/plugin.js
+++ b/bubble-mode/plugin.js
@@ -23,7 +23,7 @@ const BOTS_GROUP_TAB_PREFIX = 'plugin-workspace:hermes-bots:group:'
 const SESSION_TILE_TAB_PREFIX = 'session-tile:'
 const PANE_HIDDEN_ATTR = 'data-pane-hidden'
 
-const CSS = /* css */ `
+const PLUGIN_CSS = /* css */ `
 body.hermes-bubble-mode [data-chat-surface] [data-slot="aui_user-message-root"]:not(:has(textarea, [contenteditable="true"], input)) {
   align-items: flex-end;
 }
@@ -35,8 +35,8 @@ body.hermes-bubble-mode [data-chat-surface] [data-slot="aui_user-message-root"] 
   padding: 0.5rem 0.875rem;
   border: none;
   border-radius: 18px 18px 4px 18px;
-  background: #4a4a4e;
-  color: #f2f2f3;
+  background: color-mix(in srgb, var(--ui-bg-elevated, #4a4a4e) 70%, var(--ui-text-primary, #f2f2f3) 12%);
+  color: var(--ui-text-primary, #f2f2f3);
   box-shadow: none;
 }
 
@@ -46,13 +46,13 @@ body.hermes-bubble-mode [data-chat-surface] [data-slot="aui_user-message-root"] 
 }
 
 body.hermes-bubble-mode [data-chat-surface] [data-slot="aui_user-message-root"] .composer-human-message [data-slot="aui_user-inline-code"] {
-  background: color-mix(in srgb, #fff 18%, transparent);
+  background: color-mix(in srgb, var(--ui-text-primary, #fff) 18%, transparent);
   color: inherit;
 }
 
 body.hermes-bubble-mode [data-chat-surface] [data-slot="aui_user-message-root"] .composer-human-message button,
 body.hermes-bubble-mode [data-chat-surface] [data-slot="aui_user-message-root"] .composer-human-message svg {
-  color: #f2f2f3;
+  color: var(--ui-text-primary, #f2f2f3);
 }
 
 body.hermes-bubble-mode [data-chat-surface] [data-slot="aui_assistant-message-content"] > .aui-md {
@@ -61,8 +61,8 @@ body.hermes-bubble-mode [data-chat-surface] [data-slot="aui_assistant-message-co
   max-width: 72%;
   padding: 0.5rem 0.875rem;
   border-radius: 18px 18px 18px 4px;
-  background: #2b2b2e;
-  color: #e8e8ea;
+  background: var(--ui-chat-bubble-background, #2b2b2e);
+  color: var(--ui-text-primary, #e8e8ea);
 }
 
 body.hermes-bubble-mode [data-chat-surface] [data-slot="aui_assistant-message-content"] > .aui-md:has(
@@ -103,7 +103,8 @@ body.hermes-bubble-mode [data-chat-surface] [data-slot="aui_assistant-message-co
   max-width: 100%;
   padding: 0.5rem 0.875rem;
   border-radius: 18px 18px 18px 4px;
-  background: #2b2b2e;
+  background: var(--ui-chat-bubble-background, #2b2b2e);
+  color: var(--ui-text-primary, #e8e8ea);
   margin-top: 3px;
   margin-bottom: 3px;
 }
@@ -152,7 +153,7 @@ body.hermes-bubble-mode [data-chat-surface] [data-slot="aui_response-loading"] {
   width: fit-content;
   padding: 0.7rem 0.8rem;
   border-radius: 16px;
-  background: #2b2b2e;
+  background: var(--ui-chat-bubble-background, #2b2b2e);
 }
 
 body.hermes-bubble-mode [data-chat-surface] [data-slot="aui_response-loading"] > * {
@@ -166,15 +167,24 @@ body.hermes-bubble-mode [data-chat-surface] [data-slot="aui_response-loading"]::
   height: 6px;
   margin-right: 20px;
   border-radius: 50%;
-  background: #6b6b70;
-  box-shadow: 10px 0 0 #6b6b70, 20px 0 0 #6b6b70;
+  background: var(--ui-text-tertiary, #6b6b70);
+  box-shadow: 10px 0 0 var(--ui-text-tertiary, #6b6b70), 20px 0 0 var(--ui-text-tertiary, #6b6b70);
   animation: hermes-bubble-typing 1.2s infinite ease-in-out;
 }
 
 @keyframes hermes-bubble-typing {
-  0%, 90%, 100% { background: #b9b9bf; box-shadow: 10px 0 0 #6b6b70, 20px 0 0 #6b6b70; }
-  30% { background: #6b6b70; box-shadow: 10px 0 0 #b9b9bf, 20px 0 0 #6b6b70; }
-  60% { background: #6b6b70; box-shadow: 10px 0 0 #6b6b70, 20px 0 0 #b9b9bf; }
+  0%, 90%, 100% {
+    background: var(--ui-text-secondary, #b9b9bf);
+    box-shadow: 10px 0 0 var(--ui-text-tertiary, #6b6b70), 20px 0 0 var(--ui-text-tertiary, #6b6b70);
+  }
+  30% {
+    background: var(--ui-text-tertiary, #6b6b70);
+    box-shadow: 10px 0 0 var(--ui-text-secondary, #b9b9bf), 20px 0 0 var(--ui-text-tertiary, #6b6b70);
+  }
+  60% {
+    background: var(--ui-text-tertiary, #6b6b70);
+    box-shadow: 10px 0 0 var(--ui-text-tertiary, #6b6b70), 20px 0 0 var(--ui-text-secondary, #b9b9bf);
+  }
 }
 `
 
@@ -185,6 +195,15 @@ let applied = false
 let raf = 0
 let observer = null
 const unbinders = []
+
+// `ctx.storage.get` may hand back a promise. A read that resolves after the
+// user has toggled the setting — or after the plugin was disposed — must not
+// win. `regGen` changes on every register/dispose; the per-setting revisions
+// change on every local write. A late resolve applies only if both still
+// match what it captured when it started.
+let regGen = 0
+let enabledRev = 0
+let showWorkRev = 0
 
 function inHiddenPane(el) {
   return Boolean(el && typeof el.closest === 'function' && el.closest(`[${PANE_HIDDEN_ATTR}]`))
@@ -227,19 +246,6 @@ function groupChatFronted() {
   return false
 }
 
-function visibleBotChatSurface() {
-  if (typeof document === 'undefined') return false
-  const surfaces = document.querySelectorAll('[data-chat-surface]')
-  for (const el of surfaces) {
-    if (inHiddenPane(el)) continue
-    const target = el.getAttribute('data-composer-target') || ''
-    const anchor = el.getAttribute('data-session-anchor') || ''
-    if (target === 'main' || anchor === 'workspace') continue
-    if (target.startsWith('tile:') || anchor.startsWith('session-tile:')) return true
-  }
-  return false
-}
-
 const knownBotChatTabs = new Set()
 
 function rememberBotChatTab(id) {
@@ -253,9 +259,11 @@ function rememberBotChatTab(id) {
 }
 
 function readKnownBotChatTabs(ctx) {
+  const gen = regGen
   try {
     const value = ctx.storage?.get?.('knownBotChatTabs', [])
     const absorb = list => {
+      if (gen !== regGen) return
       if (Array.isArray(list)) for (const id of list) knownBotChatTabs.add(String(id))
       scheduleSync()
     }
@@ -264,6 +272,18 @@ function readKnownBotChatTabs(ctx) {
   } catch {
     /* ignore */
   }
+}
+
+/**
+ * The desktop decorates the canonical caption: unread counts ("Bot Chat, 2
+ * unread"), a close glyph, a dirty dot. Accept "bot chat" followed by
+ * anything that is not another letter, so decorations still match while a
+ * different session named "Bot Chats" does not.
+ */
+function isCanonicalBotChatLabel(label) {
+  if (label === 'bot chat') return true
+  if (!label.startsWith('bot chat')) return false
+  return !/\p{L}/u.test(label.charAt(8))
 }
 
 function canonicalBotChatTabSelected() {
@@ -284,7 +304,7 @@ function canonicalBotChatTabSelected() {
       .replace(/\s+/g, ' ')
       .trim()
       .toLowerCase()
-    if (label === 'bot chat') {
+    if (isCanonicalBotChatLabel(label)) {
       rememberBotChatTab(id)
       return true
     }
@@ -356,11 +376,14 @@ function scheduleSync() {
 }
 
 function readEnabled(ctx) {
+  const gen = regGen
+  const rev = enabledRev
   try {
     const value = ctx.storage?.get?.(STORAGE_KEY, true)
     if (value && typeof value.then === 'function') {
       value
         .then(resolved => {
+          if (gen !== regGen || rev !== enabledRev) return
           enabled = resolved !== false
           scheduleSync()
         })
@@ -374,11 +397,14 @@ function readEnabled(ctx) {
 }
 
 function readShowWork(ctx) {
+  const gen = regGen
+  const rev = showWorkRev
   try {
     const value = ctx.storage?.get?.(SHOW_WORK_KEY, false)
     if (value && typeof value.then === 'function') {
       value
         .then(resolved => {
+          if (gen !== regGen || rev !== showWorkRev) return
           showWork = resolved === true
           scheduleSync()
         })
@@ -393,6 +419,7 @@ function readShowWork(ctx) {
 
 function toggleShowWork() {
   showWork = !showWork
+  showWorkRev += 1
   try {
     pluginCtx?.storage?.set?.(SHOW_WORK_KEY, showWork)
   } catch {
@@ -403,6 +430,7 @@ function toggleShowWork() {
 
 function writeEnabled(value) {
   enabled = Boolean(value)
+  enabledRev += 1
   try {
     pluginCtx?.storage?.set?.(STORAGE_KEY, enabled)
   } catch {
@@ -420,7 +448,7 @@ function injectStyle() {
   if (document.getElementById(STYLE_ID)) return
   const el = document.createElement('style')
   el.id = STYLE_ID
-  el.textContent = CSS
+  el.textContent = PLUGIN_CSS
   ;(document.head || document.documentElement).appendChild(el)
 }
 
@@ -450,18 +478,15 @@ function startDomObserver() {
     subtree: true,
     childList: true,
     attributes: true,
-    attributeFilter: [
-      PANE_HIDDEN_ATTR,
-      'aria-selected',
-      'data-tree-tab',
-      'data-chat-surface',
-      'data-composer-target',
-      'data-session-anchor'
-    ]
+    // `characterData` so a tab caption that is retitled after mount (the
+    // desktop renames the tile once the session resolves) re-runs the gate.
+    characterData: true,
+    attributeFilter: [PANE_HIDDEN_ATTR, 'aria-selected', 'aria-label', 'data-tree-tab']
   })
 }
 
 function dispose() {
+  regGen += 1
   if (raf && typeof cancelAnimationFrame === 'function') {
     cancelAnimationFrame(raf)
     raf = 0
@@ -490,6 +515,7 @@ export default {
   defaultEnabled: true,
   description: 'iMessage-style chat bubbles on Bot Mode chats only. Sessions stay unchanged.',
   register(ctx) {
+    regGen += 1
     pluginCtx = ctx
     enabled = readEnabled(ctx)
     showWork = readShowWork(ctx)

--- a/bubble-mode/plugin.test.mjs
+++ b/bubble-mode/plugin.test.mjs
@@ -3,7 +3,15 @@ import fs from 'node:fs'
 import test from 'node:test'
 import vm from 'node:vm'
 
+import { botChatGateCases, buildGateDocument } from '../tests/bot-chat-gate.cases.mjs'
+
 const pluginPath = new URL('./plugin.js', import.meta.url)
+const SOURCE = fs.readFileSync(pluginPath, 'utf8')
+
+const HOOKS =
+  '\nglobalThis.__testHooks = {' +
+  ' botModeChatVisible, workspaceBotChatVisible, canonicalBotChatTabSelected,' +
+  ' isCanonicalBotChatLabel, knownBotChatTabs, styleText: PLUGIN_CSS }\n'
 
 function store(value) {
   return {
@@ -12,56 +20,188 @@ function store(value) {
   }
 }
 
-function loadDetection({ bots = true, routines = true, transcript = false } = {}) {
-  const surface = {
-    closest: () => null,
-    getAttribute: name => {
-      if (name === 'data-composer-target') return 'main'
-      if (name === 'data-session-anchor') return 'workspace'
-      return ''
-    },
-    querySelector: () => (transcript ? {} : null)
-  }
+function run(context) {
+  const source = SOURCE.replace(
+    "import { PALETTE_AREA, host } from '@hermes/plugin-sdk'",
+    "const PALETTE_AREA = 'palette'; const host = globalThis.__host"
+  )
+    .replace('export default {', 'globalThis.__plugin = {')
+    .concat(HOOKS)
+
+  context.globalThis = context
+  vm.runInNewContext(source, vm.createContext(context), { filename: pluginPath.pathname })
+  return context
+}
+
+function loadDetection(setup = {}) {
+  const { bots = true, routines = true } = setup
   const paneValues = {
     'hermes-bots:pane': bots,
     'hermes-bots:routines': routines
   }
-  const document = {
-    body: { classList: { add() {}, contains: () => false, remove() {} } },
-    querySelector: () => null,
-    querySelectorAll: selector => (selector === '[data-chat-surface]' ? [surface] : [])
-  }
-  const context = {
+  const context = run({
     __host: {
       paneVisibility: id => store(paneValues[id]),
       state: {}
     },
     CSS: { escape: value => value },
-    document,
+    document: buildGateDocument(setup),
     globalThis: null
-  }
-  context.globalThis = context
-
-  const source = fs
-    .readFileSync(pluginPath, 'utf8')
-    .replace(
-      "import { PALETTE_AREA, host } from '@hermes/plugin-sdk'",
-      "const PALETTE_AREA = 'palette'; const host = globalThis.__host"
-    )
-    .replace('export default {', 'globalThis.__plugin = {')
-    .concat('\nglobalThis.__testHooks = { botModeChatVisible, workspaceBotChatVisible }\n')
-
-  vm.runInNewContext(source, vm.createContext(context), { filename: pluginPath.pathname })
+  })
+  for (const id of setup.remembered || []) context.__testHooks.knownBotChatTabs.add(id)
   return context.__testHooks
 }
 
-test('Bubble Mode stays active while a Bot Chat transcript remounts during send', () => {
-  const detection = loadDetection({ transcript: false })
+/** A document with a real class list plus the bits `register()` touches. */
+function lifecycleDocument() {
+  const classes = new Set()
+  const gate = buildGateDocument({ bots: true, routines: true })
+  return {
+    classes,
+    body: {
+      classList: {
+        add: name => classes.add(name),
+        remove: name => classes.delete(name),
+        contains: name => classes.has(name)
+      }
+    },
+    createElement: () => ({ id: '', textContent: '', remove() {} }),
+    documentElement: {},
+    getElementById: () => null,
+    head: { appendChild() {} },
+    querySelector: gate.querySelector,
+    querySelectorAll: gate.querySelectorAll
+  }
+}
 
-  assert.equal(detection.botModeChatVisible(), true)
+function deferred() {
+  let resolve
+  const promise = new Promise(r => {
+    resolve = r
+  })
+  return { promise, resolve }
+}
+
+/** Load the plugin and call register() with a storage whose `enabled` read is pending. */
+function loadLifecycle() {
+  const document = lifecycleDocument()
+  const pending = deferred()
+  const observed = []
+  const commands = new Map()
+  let disposer = null
+
+  const context = run({
+    __host: {
+      paneVisibility: () => store(true),
+      state: {}
+    },
+    CSS: { escape: value => value },
+    document,
+    globalThis: null,
+    MutationObserver: class {
+      observe(_target, options) {
+        observed.push(options)
+      }
+      disconnect() {}
+    }
+  })
+
+  context.__plugin.register({
+    storage: {
+      get: key => (key === 'enabled' ? pending.promise : key === 'knownBotChatTabs' ? [] : false),
+      set: () => undefined
+    },
+    register: entry => commands.set(entry.data.id, entry.data),
+    onDispose: fn => {
+      disposer = fn
+    }
+  })
+
+  return {
+    classes: document.classes,
+    commands,
+    dispose: () => disposer && disposer(),
+    observed,
+    resolveEnabled: pending.resolve,
+    settle: () => new Promise(r => setImmediate(r))
+  }
+}
+
+test('the shared Bot Chat gate matrix holds for bubble-mode', () => {
+  for (const testCase of botChatGateCases) {
+    const detection = loadDetection(testCase.setup)
+    assert.equal(detection.botModeChatVisible(), testCase.expect, testCase.name)
+  }
+})
+
+test('Bubble Mode stays active while a Bot Chat transcript remounts during send', () => {
+  assert.equal(loadDetection({ routines: true }).botModeChatVisible(), true)
 })
 
 test('Bubble Mode still rejects non-Bot-Chat workspaces', () => {
   assert.equal(loadDetection({ routines: false }).botModeChatVisible(), false)
   assert.equal(loadDetection({ bots: false }).botModeChatVisible(), false)
+})
+
+test('a decorated Bot Chat caption matches; a different session name does not', () => {
+  const { isCanonicalBotChatLabel } = loadDetection()
+
+  assert.equal(isCanonicalBotChatLabel('bot chat'), true)
+  assert.equal(isCanonicalBotChatLabel('bot chat, 2 unread'), true)
+  assert.equal(isCanonicalBotChatLabel('bot chat ×'), true)
+  assert.equal(isCanonicalBotChatLabel('bot chats'), false)
+  assert.equal(isCanonicalBotChatLabel('group: standup'), false)
+})
+
+test('a late settings read never overwrites a newer toggle', async () => {
+  const app = loadLifecycle()
+  assert.equal(app.classes.has('hermes-bubble-mode'), true)
+
+  app.commands.get('bubble-mode.toggle').run()
+  assert.equal(app.classes.has('hermes-bubble-mode'), false)
+
+  app.resolveEnabled(true)
+  await app.settle()
+
+  assert.equal(app.classes.has('hermes-bubble-mode'), false)
+})
+
+test('a settings read that resolves after dispose adds no body class', async () => {
+  const app = loadLifecycle()
+
+  app.dispose()
+  assert.equal(app.classes.has('hermes-bubble-mode'), false)
+
+  app.resolveEnabled(true)
+  await app.settle()
+
+  assert.equal(app.classes.has('hermes-bubble-mode'), false)
+})
+
+test('the DOM observer watches captions and no longer watches dead chat-surface attributes', () => {
+  const app = loadLifecycle()
+  const [options] = app.observed
+
+  assert.ok(options)
+  assert.equal(options.characterData, true)
+  assert.deepEqual(Array.from(options.attributeFilter), [
+    'data-pane-hidden',
+    'aria-selected',
+    'aria-label',
+    'data-tree-tab'
+  ])
+})
+
+test('bubble colours come from Hermes theme tokens, with the dark hexes only as fallbacks', () => {
+  const { styleText } = loadDetection()
+  const literals = ['#4a4a4e', '#2b2b2e', '#e8e8ea', '#f2f2f3', '#6b6b70', '#b9b9bf']
+
+  for (const hex of literals) {
+    const total = (styleText.match(new RegExp(hex, 'g')) || []).length
+    const fallbacks = (styleText.match(new RegExp(`var\\(--[a-z-]+,\\s*${hex}\\)`, 'g')) || []).length
+    assert.ok(total > 0, `${hex} should survive as a fallback`)
+    assert.equal(total, fallbacks, `${hex} appears outside a var() fallback`)
+  }
+  // The shared token is read, never redefined.
+  assert.equal(/--ui-chat-bubble-background\s*:/.test(styleText), false)
 })

--- a/task-dock/plugin.js
+++ b/task-dock/plugin.js
@@ -32,7 +32,7 @@ const ITEM_TEXT_MAX = 300
 const STATUS_CLASS_MAX = 240
 const STATUSES = new Set(['pending', 'in_progress', 'completed', 'cancelled', 'unknown'])
 
-const CSS = /* css */ `
+const PLUGIN_CSS = /* css */ `
 body:not(.hermes-task-dock) [${DOCK_ATTR}] {
   display: none !important;
 }
@@ -350,6 +350,17 @@ function readKnownBotChatTabs(ctx) {
   }
 }
 
+/**
+ * Same rule as bubble-mode: the desktop decorates the canonical caption
+ * ("Bot Chat, 2 unread", a close glyph), so match "bot chat" followed by any
+ * non-letter, while a differently named session ("Bot Chats") stays out.
+ */
+function isCanonicalBotChatLabel(label) {
+  if (label === 'bot chat') return true
+  if (!label.startsWith('bot chat')) return false
+  return !/\p{L}/u.test(label.charAt(8))
+}
+
 function canonicalBotChatTabSelected() {
   if (typeof document === 'undefined') return false
   const tabs = document.querySelectorAll('[data-tree-tab][aria-selected="true"]')
@@ -361,7 +372,7 @@ function canonicalBotChatTabSelected() {
       .replace(/\s+/g, ' ')
       .trim()
       .toLowerCase()
-    if (label === 'bot chat') {
+    if (isCanonicalBotChatLabel(label)) {
       rememberBotChatTab(id)
       return true
     }
@@ -948,7 +959,10 @@ function viewKey(view, stale) {
     items: view.items.map(it => [it.text, it.status]),
     stale,
     collapsed,
-    ageBucket: stale ? Math.floor(view.capturedAt / 15000) : 0
+    // Bucket the *age*, not the capture time: keying on `capturedAt` never
+    // changes for a stored snapshot, so the "last updated …" label froze at
+    // "just now" for as long as the dock stayed mounted.
+    ageBucket: stale ? Math.floor((Date.now() - Number(view.capturedAt || 0)) / 15000) : 0
   })
 }
 
@@ -1096,7 +1110,7 @@ function injectStyle() {
   if (document.getElementById(STYLE_ID)) return
   const el = document.createElement('style')
   el.id = STYLE_ID
-  el.textContent = CSS
+  el.textContent = PLUGIN_CSS
   ;(document.head || document.documentElement).appendChild(el)
 }
 

--- a/task-dock/plugin.test.mjs
+++ b/task-dock/plugin.test.mjs
@@ -3,17 +3,24 @@ import fs from 'node:fs'
 import test from 'node:test'
 import vm from 'node:vm'
 
+import { botChatGateCases, buildGateDocument } from '../tests/bot-chat-gate.cases.mjs'
+
 const pluginPath = new URL('./plugin.js', import.meta.url)
 
-function loadSelection({ routines = true } = {}) {
+function loadSelection(setup = {}) {
+  const { bots = true, routines = true, now = null } = setup
+  const paneValues = {
+    'hermes-bots:pane': bots,
+    'hermes-bots:routines': routines
+  }
   const context = {
     __host: {
-      paneVisibility: id => ({ get: () => (id === 'hermes-bots:routines' ? routines : false) }),
+      paneVisibility: id => ({ get: () => Boolean(paneValues[id]) }),
       state: {}
     },
     CSS: { escape: value => value },
-    Date,
-    document: { querySelectorAll: () => [] },
+    Date: now ? { now } : Date,
+    document: buildGateDocument(setup),
     globalThis: null,
     setInterval: () => 0,
     setTimeout: () => 0
@@ -28,10 +35,13 @@ function loadSelection({ routines = true } = {}) {
     )
     .replace('export default {', 'globalThis.__plugin = {')
     .concat(
-      '\nglobalThis.__testHooks = { matchingStoredSnapshot, workspaceBotChatVisible, markLiveSources, clearLiveSources, isCompletedView }\n'
+      '\nglobalThis.__testHooks = { matchingStoredSnapshot, workspaceBotChatVisible, botModeChatVisible,' +
+        ' isCanonicalBotChatLabel, knownBotChatTabs, markLiveSources, clearLiveSources, isCompletedView,' +
+        ' viewKey, relativeTime }\n'
     )
 
   vm.runInNewContext(source, vm.createContext(context), { filename: pluginPath.pathname })
+  for (const id of setup.remembered || []) context.__testHooks.knownBotChatTabs.add(id)
   return context.__testHooks
 }
 
@@ -112,4 +122,35 @@ test('completed lists auto-hide by counts or terminal item statuses', () => {
   terminal.total = 0
   assert.equal(isCompletedView(terminal), true)
   assert.equal(isCompletedView(active), false)
+})
+
+test('the shared Bot Chat gate matrix holds for task-dock', () => {
+  for (const testCase of botChatGateCases) {
+    const { botModeChatVisible } = loadSelection(testCase.setup)
+    assert.equal(botModeChatVisible(), testCase.expect, testCase.name)
+  }
+})
+
+test('a decorated Bot Chat caption matches; a different session name does not', () => {
+  const { isCanonicalBotChatLabel } = loadSelection()
+
+  assert.equal(isCanonicalBotChatLabel('bot chat'), true)
+  assert.equal(isCanonicalBotChatLabel('bot chat, 2 unread'), true)
+  assert.equal(isCanonicalBotChatLabel('bot chat ×'), true)
+  assert.equal(isCanonicalBotChatLabel('bot chats'), false)
+})
+
+test('a stale snapshot ages instead of freezing at "just now"', () => {
+  let clock = 1_700_000_000_000
+  const { relativeTime, viewKey } = loadSelection({ now: () => clock })
+  const view = { ...snapshot(), capturedAt: clock }
+
+  assert.equal(relativeTime(view.capturedAt), 'just now')
+  const fresh = viewKey(view, true)
+
+  clock += 10 * 60 * 1000
+  assert.equal(relativeTime(view.capturedAt), '10m ago')
+  // The render key has to move too, or renderDock() short-circuits and the
+  // "last updated …" label keeps whatever text it was first given.
+  assert.notEqual(viewKey(view, true), fresh)
 })

--- a/tests/bot-chat-gate.cases.mjs
+++ b/tests/bot-chat-gate.cases.mjs
@@ -1,0 +1,141 @@
+/**
+ * Shared Bot Chat detection matrix.
+ *
+ * bubble-mode and task-dock each carry their own copy of the gate
+ * (`botModeChatVisible`): single-file disk plugins cannot import a shared
+ * runtime module. So the *tests* are shared instead — both suites import this
+ * matrix and run every case against their own copy, and the two cannot drift
+ * without one of them going red.
+ *
+ * Case shape:
+ *   {
+ *     name,
+ *     setup: {
+ *       bots,          // hermes-bots:pane visible          (default true)
+ *       routines,      // hermes-bots:routines visible      (default false)
+ *       groupSelected, // a group-chat tab is fronted       (default false)
+ *       remembered,    // tab ids already seen as "Bot Chat" (default [])
+ *       tabs: [{ id, selected, label, hidden }]
+ *     },
+ *     expect
+ *   }
+ */
+
+const GROUP_TAB_PREFIX = 'plugin-workspace:hermes-bots:group:'
+
+function makeTab({ id, selected = false, label = '', hidden = false }) {
+  return {
+    getAttribute(name) {
+      if (name === 'data-tree-tab') return id
+      if (name === 'aria-selected') return selected ? 'true' : 'false'
+      if (name === 'aria-label') return label
+      return ''
+    },
+    closest: selector => (hidden && selector === '[data-pane-hidden]' ? { id: 'hidden-pane' } : null),
+    textContent: label
+  }
+}
+
+function attrValue(selector) {
+  const match = /="([^"]*)"/.exec(selector)
+  return match ? match[1] : ''
+}
+
+/**
+ * Build the `document` stand-in a plugin's gate needs for one case. Both vm
+ * harnesses use this so the fixtures are identical on each side.
+ */
+export function buildGateDocument(setup = {}) {
+  const tabs = (setup.tabs || []).map(makeTab)
+  if (setup.groupSelected) {
+    tabs.push(makeTab({ id: `${GROUP_TAB_PREFIX}room`, selected: true, label: 'Group: room' }))
+  }
+  return {
+    body: { classList: { add() {}, contains: () => false, remove() {} } },
+    querySelector(selector) {
+      const wanted = attrValue(selector)
+      return tabs.find(tab => tab.getAttribute('data-tree-tab') === wanted) || null
+    },
+    querySelectorAll(selector) {
+      if (selector === '[data-tree-tab][aria-selected="true"]') {
+        return tabs.filter(tab => tab.getAttribute('aria-selected') === 'true')
+      }
+      if (selector.startsWith('[data-tree-tab^=')) {
+        const prefix = attrValue(selector)
+        return tabs.filter(tab => tab.getAttribute('data-tree-tab').startsWith(prefix))
+      }
+      return []
+    }
+  }
+}
+
+export const botChatGateCases = [
+  {
+    name: 'routines pane visible → Bot Chat owns the workspace',
+    setup: { bots: true, routines: true, tabs: [] },
+    expect: true
+  },
+  {
+    name: 'routines pane closed and no canonical tab → inactive',
+    setup: { bots: true, routines: false, tabs: [] },
+    expect: false
+  },
+  {
+    name: 'Bots pane off → inactive even with the routines pane up',
+    setup: { bots: false, routines: true, tabs: [] },
+    expect: false
+  },
+  {
+    name: 'canonical tab labelled "Bot Chat" is selected → active',
+    setup: {
+      bots: true,
+      routines: false,
+      tabs: [{ id: 'session-tile:canonical', selected: true, label: 'Bot Chat' }]
+    },
+    expect: true
+  },
+  {
+    name: 'canonical tab with an unread suffix still matches',
+    setup: {
+      bots: true,
+      routines: false,
+      tabs: [{ id: 'session-tile:canonical', selected: true, label: 'Bot Chat, 2 unread' }]
+    },
+    expect: true
+  },
+  {
+    name: 'a different session named "Bot Chats" must not match',
+    setup: {
+      bots: true,
+      routines: false,
+      tabs: [{ id: 'session-tile:other', selected: true, label: 'Bot Chats' }]
+    },
+    expect: false
+  },
+  {
+    name: 'group chat tab fronted → inactive',
+    setup: { bots: true, routines: true, groupSelected: true, tabs: [] },
+    expect: false
+  },
+  {
+    name: 'remembered tab id with a scrambled caption → active',
+    setup: {
+      bots: true,
+      routines: false,
+      remembered: ['session-tile:canonical'],
+      tabs: [{ id: 'session-tile:canonical', selected: true, label: 'Session 41' }]
+    },
+    expect: true
+  },
+  {
+    name: 'canonical tab inside a hidden pane → inactive',
+    setup: {
+      bots: true,
+      routines: false,
+      tabs: [{ id: 'session-tile:canonical', selected: true, label: 'Bot Chat', hidden: true }]
+    },
+    expect: false
+  }
+]
+
+export default botChatGateCases


### PR DESCRIPTION
Round-2 review fixes (Codex 8, 11, 13; Grok 8, 10, 11, 12; Claude 10, 18). Also fixes a module constant named CSS that shadowed the browser's CSS.escape in both plugins. 35 JS tests pass incl. a shared Bot Chat gate matrix and the first bot-sections suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)